### PR TITLE
Experimental unit support, add Tesla

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,0 +1,4 @@
+* v0.1.0
+- support for all SI base units and most compound SI units
+- *experimental* SI unit support for converting SI units to natural
+  units according to HEP Lorentz-Heaviside convention

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -1508,11 +1508,6 @@ macro toImpl(x: typed, to: static CTCompoundUnit): NimNode =
     error("Cannot convert " & $(xCT.toNimType()) & " to " & $(yCT.toNimType()) & " as they represent different " &
       "quantities!")
 
-#macro to(x: untyped, to: untyped): untyped =
-#  let yCT = parseCTUnit(to)
-#  result = quote do:
-#    toImpl(`x`, `yCT`)
-
 {.experimental: "dotOperators".}
 macro `.`*[T: SomeUnit|SomeNumber](x: T; y: untyped): untyped =
   ## macro to allow to generate new types on the fly


### PR DESCRIPTION
Adds experimental natural unit conversions (only SI ↦ natural) for the typical high energy physics convention based on Lorentz-Heaviside units.