### PR TITLE
Fix equality using `==`

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,6 @@
+* v0.1.2
+- fix ~==~ macro for same types of different names
+
 * v0.1.1
 - fix bug causing "Pound-force" parsing to fail
 

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -1338,7 +1338,7 @@ proc toBaseType(x: CTCompoundUnit): CTCompoundUnit =
     result.add u.toBaseType
 
 ## TODO: we should really combine these macros somewhat?
-macro `==`*[T: SomeUnit](x, y: T): bool =
+macro `==`*[T: SomeUnit; U: SomeUnit](x: T, y: U): bool =
   var xCT = parseCTUnit(x)
   var yCT = parseCTUnit(y)
   if xCT == yCT:

--- a/tests/tunchained.nim
+++ b/tests/tunchained.nim
@@ -619,6 +619,22 @@ suite "Unchained - imperial units":
       check Ns =~= 4.44822.N•s
       check type(Ns) is N•s
 
+
+suite "Unchained - Bug issues":
+  test "Different names in equality operator":
+    block:
+      let a = 1.N•s
+      let b = 1.`N*s`
+      check typeof(a) is typeof(b)
+      check a == b
+    block:
+      let a = 1.N•s
+      let b = 1.kg•m•s⁻¹
+      # this cannot hold, as the nim compile does not recognize that they are the same
+      check typeof(a) isnot typeof(b)
+      # but this works
+      check a == b
+
 #converter to_eV(x: GeV): eV =
 #  echo "toEv!"
 #  (x.float * 1e-9).eV


### PR DESCRIPTION
As the macro only had one generic argument, there was no way to have two "different" types that are actually similar.