### PR TITLE
Fix unit ordering and radian / steradian computations

### DIFF
--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -881,9 +881,14 @@ proc `<`(a, b: CTUnit): bool =
   elif a.unitKind > b.unitKind:
     result = false
   else:
-    if a.power < b.power:
+    ## NOTE: the power seem "inverted". This is because we wish to have units with
+    ## larger powers ``in front`` of units with smaller powers. E.g.
+    ## `Meter•Meter⁻¹` instead of `Meter⁻¹•Meter`
+    ## We cannot sort in descending order, because the actual units in the `UnitKind`
+    ## enum needs to be respected.
+    if a.power > b.power:
       result = true
-    elif a.power > b.power:
+    elif a.power < b.power:
       result = false
     else:
       result = a.siPrefix < b.siPrefix

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -80,11 +80,18 @@ type
   KiloGram•Meter²•Second⁻³•Ampere⁻²* = distinct ElectricResistance
   KiloGram•Meter⁻¹•Second⁻²* = distinct Pressure
   KiloGram•Meter⁻³* = distinct Density
+  KiloGram•Ampere⁻¹•Second⁻²* = distinct MagneticFieldStrength
+  # the following two are a bit problematic, as this is not a rea
+  # identity. `Meter•Meter⁻¹` can, but does not ``need`` to be an angle.
   Meter•Meter⁻¹* = distinct Angle
   Meter²•Meter⁻²* = distinct SolidAngle
-  KiloGram•Ampere⁻¹•Second⁻²* = distinct MagneticFieldStrength
+
 
   ## derived SI units
+  ## TODO: are these actually needed? We do all work in the internal CT
+  ## unit base anyway.
+  ## Well, but these help if the user computes such combinations manually
+  ## and gets those units.
   Newton* = KiloGram•Meter•Second⁻²
   Joule* = KiloGram•Meter²•Second⁻²
   Volt* = KiloGram•Meter²•Ampere⁻¹•Second⁻³
@@ -95,10 +102,14 @@ type
   Henry* = KiloGram•Meter²•Second⁻²•Ampere⁻²
   Farad* = Second⁴•Ampere²•Meter⁻²•KiloGram⁻¹
   Pascal* = KiloGram•Meter⁻¹•Second⁻²
-  Radian* = Meter•Meter⁻¹
-  Steradian* = Meter²•Meter⁻²
   ## TODO: distinct quantity of Magnetic
   Tesla* = KiloGram•Ampere⁻¹•Second⁻²
+  # radian and steradian are distinct versions as they should not be converted
+  # to that representation. Also Meter•Meter⁻¹ is not necessarily an angle.
+  # TODO: think about removing Meter•Meter⁻¹ from here and only writing as
+  # `distinct Angle`.
+  Radian* = distinct Meter•Meter⁻¹
+  Steradian* = distinct Meter²•Meter⁻²
 
   ## other units
   ElectronVolt* = distinct Energy

--- a/tests/tunchained.nim
+++ b/tests/tunchained.nim
@@ -511,6 +511,17 @@ suite "Unchained - practical examples turned tests":
 
     check vacTime((2.7e-4).Pa•m³•s⁻¹•m⁻², 35.311.m², 3600.s, 685.L•s⁻¹, 1.0e-7.mbar) =~= 347.9551.Hour
 
+  test "Cosine with radian argument":
+    let ω = 100.rad•s⁻¹
+    let A = 10.cm
+    let φ = Pi.rad
+    let t = 1.s
+    let argument = ω * t + φ
+    check typeof(argument) is Radian
+    check typeof(ω) is Second⁻¹•Radian
+    check typeof(A * cos(argument)) is CentiMeter
+    check A * cos(argument) =~= -8.62319.cm
+
 suite "Unchained - imperial units":
   test "Pound":
     block:


### PR DESCRIPTION
Fixes the issues with radians encountered in https://github.com/SciNim/getting-started/pull/30/.

It is fixed by first of all correcting the ordering of units. Higher powers are considered *lower* precedence, as they should appear before lower powers (to keep fractional logic).

Then makes radian and steradian distinct meter based units to avoid conversions in simple additive maths.