### PR TITLE
Add Becquerel (Bq) as a unit for activity

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,5 @@
+* v0.1.6
+- add Becquerel as a unit for activity
 * v0.1.5
 - fix issue #16, division of compound units works correctly now
 - add Planck constant as =hp= and Boltzmann constant as =k=  

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -110,6 +110,7 @@ type
   # `distinct Angle`.
   Radian* = distinct Meter•Meter⁻¹
   Steradian* = distinct Meter²•Meter⁻²
+  Becquerel* = distinct Second⁻¹
 
   ## other units
   ElectronVolt* = distinct Energy
@@ -172,6 +173,7 @@ type
   yr* = Year
   L* = Liter
   T* = Tesla
+  Bq* = Becquerel
 
   ## imperial shorthand
   inch* = Inch
@@ -202,7 +204,7 @@ type
     # derived quantities
     qkFrequency, qkVelocity, qkAcceleration, qkArea, qkMomentum, qkForce, qkEnergy, qkElectricPotential,
     qkCharge, qkPower, qkElectricResistance, qkInductance, qkCapacitance, qkPressure, qkDensity,
-    qkAngle, qkSolidAngle, qkMagneticFieldStrength
+    qkAngle, qkSolidAngle, qkMagneticFieldStrength, qkActivity
 
   ## enum storing all known units (their base form) to allow easier handling of unit conversions
   ## Enum value is the default name of the unit
@@ -230,6 +232,7 @@ type
     ukRadian = "Radian"
     ukSteradian = "Steradian"
     ukTesla = "Tesla"
+    ukBecquerel = "Becquerel"
     # natural units
     ukNaturalLength = "NaturalLength" # length
     ukNaturalMass = "NaturalMass" # mass
@@ -581,6 +584,7 @@ proc toQuantity(unitKind: UnitKind): QuantityKind =
   of ukRadian: result = qkAngle
   of ukSteradian: result = qkSolidAngle
   of ukTesla: result = qkMagneticFieldStrength
+  of ukBecquerel: result = qkActivity
   # natural units
   of ukNaturalLength: result = qkLength
   of ukNaturalMass: result = qkMass
@@ -718,6 +722,8 @@ proc toCTBaseUnitSeq(unitKind: UnitKind): seq[CTBaseUnit] =
     result.add toCTBaseUnit(ukGram, siPrefix = siKilo)
     result.add toCTBaseUnit(ukAmpere, power = -1)
     result.add toCTBaseUnit(ukSecond, power = -2)
+  of ukBecquerel:
+    result.add toCTBaseUnit(ukSecond, power = -1)
   of ukElectronVolt:
     ## our logic is incomplete, since it's missing proper conversions ouside of SI prefixes!
     result.add toCTBaseUnitSeq(ukJoule)
@@ -1172,6 +1178,7 @@ proc parseUnitKind(s: string): UnitKind =
   of "rad", "Radian": result = ukRadian
   of "sr", "Steradian": result = ukSteradian
   of "T", "Tesla": result = ukTesla
+  of "Bq", "Becquerel": result = ukBecquerel
   # natural units
   of "NaturalLength": result = ukNaturalLength # length:
   of "NaturalMass": result = ukNaturalMass # mass:

--- a/tests/tresolveAlias.nim
+++ b/tests/tresolveAlias.nim
@@ -99,6 +99,8 @@ suite "Resolve unit aliases":
     check isAUnit(Pascal)
     check isAUnit(Radian)
     check isAUnit(Steradian)
+    check isAUnit(Tesla)
+    check isAUnit(Becquerel)
 
     ## other units
     check isAUnit(ElectronVolt)

--- a/tests/tunchained.nim
+++ b/tests/tunchained.nim
@@ -416,6 +416,16 @@ suite "Unchained - CT errors":
     ## TODO: FIXME comparison fails due to ???. Values are correct though!
     #check b.to(mm⁻²) == 10e-5.MilliMeter⁻²
 
+suite "Unchained - Test of individual units":
+  test "Becquerel":
+    let A = 10.GBq
+    check A.to(Bq) == 10_000_000_000.Bq
+    check typeof(A) is GigaBecquerel
+    proc counts(A: Bq, time: Second): float =
+      # counts in a given time
+      result = A * time
+    check counts(A.to(Bq), 10.s) == 100_000_000_000.0
+
 suite "Unchained - Conversion between units requiring scale (no SI prefix)":
   test "Conversion of eV to Joule":
     let x = 1.eV


### PR DESCRIPTION
Pretty self explanatory. Bq as a unit for activity of a radioactive source.