### PR TITLE
Fixes to math involving SI prefixes of compound units

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,10 @@
+* v0.1.8
+- fix generation of SI prefixes if =exclude= is used. Previously
+  mapping of short to long prefixes was broken if =exclude= was used.
+- fix math of compound units that involved conversions SI prefixes and
+  conversions to base units (i.e. Tesla to kg•s⁻²•A⁻¹) by adding a
+  global SI prefix factor field to =CTCompoundUnit=
+- reorder =ukDegree= in =UnitKind= enum 
 * v0.1.7
 - emit SI prefixed versions of Bq
 * v0.1.6

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -999,14 +999,19 @@ proc `==`(a, b: CTCompoundUnit): bool =
   ## Since there are multiple representations of the same unit (e.g. `Newton` as
   ## a single CTUnit or a `CTCompoundUnit` comprising base units up to `Newton`)
   ## we have to flatten each input and then compare for same base units & powers.
-  let aFlat = a.flatten.simplify.units.sorted
-  let bFlat = b.flatten.simplify.units.sorted
+  let aFlat = a.flatten.simplify
+  let bFlat = b.flatten.simplify
+  let aFlatSeq = aFlat.units.sorted
+  let bFlatSeq = bFlat.units.sorted
+
   # to really make sure they are equal have to compare the si prefix of each
-  if aFlat.len != bFlat.len:
+  if aFlatSeq.len != bFlatSeq.len:
     return false
-  for idx in 0 ..< aFlat.len:
-    if aFlat[idx] != bFlat[idx]:
+  for idx in 0 ..< aFlatSeq.len:
+    if aFlatSeq[idx] != bFlatSeq[idx]:
       return false
+  if aFlat.siPrefix != bFlat.siPrefix:
+    return false
   result = true
 
 iterator getPow10Digits(x: int): int =

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -207,7 +207,7 @@ type
     qkAngle, qkSolidAngle, qkMagneticFieldStrength, qkActivity
 
   ## enum storing all known units (their base form) to allow easier handling of unit conversions
-  ## Enum value is the default name of the unit
+  ## Enum value is the default name of the unit. Note: Order is important! (e.g. for `isCompound`)
   UnitKind* = enum
     ukUnitLess = "UnitLess"
     ukGram = "Gram"
@@ -217,7 +217,7 @@ type
     ukKelvin = "Kelvin"
     ukMol = "Mol"
     ukCandela = "Candela"
-    # derived SI units
+    # derived SI units, all compound
     ukNewton = "Newton"
     ukJoule = "Joule"
     ukVolt = "Volt"
@@ -230,6 +230,7 @@ type
     ukPascal = "Pascal"
     ukBar = "Bar"
     ukRadian = "Radian"
+    ukDegree = "Degree"
     ukSteradian = "Steradian"
     ukTesla = "Tesla"
     ukBecquerel = "Becquerel"
@@ -243,7 +244,6 @@ type
     ukElectronVolt = "ElectronVolt"
     ukLiter = "Liter"
     # additional non compound units
-    ukDegree = "Degree"
     ukMinute = "Minute"
     ukHour = "Hour"
     ukDay = "Day"

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -485,7 +485,9 @@ proc genSiPrefixes(n: NimNode, genShort: bool, genLong: bool,
   if genLong:
     for (si, prefix) in SiPrefixStringsLong:
       if prefix == siIdentity: continue
-      if si in excludes: continue
+      if si in excludes:
+        result.add ident("_") # if we exclude, add placeholder. Used to mark for cross reference long / short
+        continue
       let typStr = ident($si & typ.strVal)
       if typStr.strVal == "KiloGram": continue # skip generation of `KiloGram`
       let isTyp = nnkDistinctTy.newTree(typ)
@@ -493,7 +495,9 @@ proc genSiPrefixes(n: NimNode, genShort: bool, genLong: bool,
   if genShort:
     for (si, prefix) in SiPrefixStringsShort:
       if prefix == siIdentity: continue
-      if si in excludes: continue
+      if si in excludes:
+        result.add ident("_") # if we exclude, add placeholder. Used to mark for cross reference long / short
+        continue
       let typStr = ident($si & typ.strVal)
       if typStr.strVal == "kg": continue # predefined as well to have same number of elements in this seq
       result.add typStr
@@ -527,7 +531,9 @@ macro generateSiPrefixedUnits*(units: untyped): untyped =
     for si in sisLong:
       result.add si
     ## generate cross references from long to short
+    let skipIdent = ident("_") # if a prefix is excluded, added as `_`. Thus skip those cross references
     for (siShort, siLong) in zip(sisShort, sisLong):
+      if eqIdent(siShort, skipIdent) or eqIdent(siLong, skipIdent): continue
       result.add nnkTypeDef.newTree(nnkPostfix.newTree(ident"*", siShort), newEmptyNode(), siLong[0][1])
 
 generateSiPrefixedUnits:

--- a/tests/tunchained.nim
+++ b/tests/tunchained.nim
@@ -417,6 +417,14 @@ suite "Unchained - CT errors":
     #check b.to(mm⁻²) == 10e-5.MilliMeter⁻²
 
 suite "Unchained - Test of individual units":
+  test "Tesla":
+    let B = 10.GT
+    check typeof(B) is GigaTesla # `exclude` in SI generation was broken
+    check B * 10.s == 100_000_000_000.T•s # math works
+    check B / 10.s == 1_000_000_000.T•s⁻¹
+    check B + 1.T  == 10_000_000_001.T
+    check B - 1.T  ==  9_999_999_999.T
+
   test "Becquerel":
     let A = 10.GBq
     check A.to(Bq) == 10_000_000_000.Bq
@@ -425,6 +433,11 @@ suite "Unchained - Test of individual units":
       # counts in a given time
       result = A * time
     check counts(A.to(Bq), 10.s) == 100_000_000_000.0
+    # auto conversion of Giga works + math works
+    check A * 10.s == 100_000_000_000.0
+    check A / 10.s == 1_000_000_000.s⁻²
+    check A + 1.Bq == 10_000_000_001.Bq
+    check A - 1.Bq ==  9_999_999_999.Bq
 
 suite "Unchained - Conversion between units requiring scale (no SI prefix)":
   test "Conversion of eV to Joule":


### PR DESCRIPTION
If a compound unit had an SI prefix and was involved in math that forced a conversion to its base type, the SI prefix of the compound was dropped.

In addition the SI prefix generation of units that used the `exclude` feature, were partially wrong, because the short and long names were mapped incorrectly.