### PR TITLE
Allow exporting units in `defUnits`, add Gauss, Kelvin->eV, ...

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,19 @@
+* v0.1.10
+- add =Gauss= as a unit
+- allow conversion of =Kelvin= to natural units
+- allow units with `·` instead of `•`
+  Note: this is only for units that user *hands and constructs
+  themselves*. Predefined units or those auto generated when by `*` and
+  similar still concat units using `•`. So YMMV and all that, but it
+  opens up the possibility of being more flexible in the future.
+- add constant =m_u=, defined by =M_u / N_A=
+- rename Boltzmann constant from =k= to =k_B=
+- add =pretty= for units that allows a =short= parameter. That way the
+  unit will be string converted to a name with the short unit naming,
+  i.e. m•s⁻¹ instead of Meter•Second⁻¹. For now the default will
+  remain the long version, but that may change in the future.
+  
+        
 * v0.1.9
 - add =sqrt= for units that are a perfect square
 - add =abs= for units  

--- a/changelog.org
+++ b/changelog.org
@@ -1,4 +1,6 @@
 * v0.1.10
+- =defUnits= now has an =export= option to define a unit that is
+  exported (therefore this =defUnit= can only be used at top level!)
 - add =Gauss= as a unit
 - allow conversion of =Kelvin= to natural units
 - allow units with `·` instead of `•`

--- a/src/unchained/constants.nim
+++ b/src/unchained/constants.nim
@@ -12,10 +12,11 @@ let
   m_e_c2* = 0.510998928.MeV
   N_A* = 6.02214076e23.mol⁻¹
   M_u* = 0.99999999965e-3.kg•mol⁻¹
+  m_u* = M_u / N_A
   m_μ_eV* = 105.6583755e6.eV # / c²
   m_μ* = 1.883531627e-28.kg # 105.6583755e3 # MeV / c²
   π* = PI
   r_e* = e*e / (4 * π * ε_0 * m_e * c * c) # classical electron radius
   #K = 4 * π * N_A * r_e * r_e * m_e_c2 * (100.0^2)# [MeV mol⁻¹ cm²]
-  k* = 1.380649e-23.Joule•Kelvin⁻¹
+  k_B* = 1.380649e-23.Joule•Kelvin⁻¹
   hp* = 6.62607015e-34.Joule•Hertz⁻¹

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -699,6 +699,9 @@ macro generateSiPrefixedUnits*(units: untyped): untyped =
       if eqIdent(siShort, skipIdent) or eqIdent(siLong, skipIdent): continue
       result.add nnkTypeDef.newTree(nnkPostfix.newTree(ident"*", siShort), newEmptyNode(), siLong[0][1])
 
+## XXX: should this also generate the aliases for the short names?
+## Or make macro more generic with an additional "generate SI" option and by default it simply
+## generates types?
 generateSiPrefixedUnits:
   (m, Meter)
   (s, Second)

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -1389,7 +1389,8 @@ proc parseCTUnitUnicode(x: string): CTCompoundUnit =
   ## c) "meter per second squared" -> "meterPerSecondSquared"
   ## a) and b) can be parsed together by both looking for `m` as well as `Meter` in each
   ## element. Verbose always start capital letters, shorthand depending on SI prefix / unit (N, V, A...)
-  let xTStrs = x.split("•")
+  let xTStrs = if "•" in x: x.split("•")
+               else: x.split("·")
   for el in xTStrs:
     var mel = el
     let prefix = mel.parseSiPrefix

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -1815,7 +1815,8 @@ proc baseUnitToNaturalUnit(b: CTBaseUnit): CTUnit =
     result = initCTUnit("eV⁻¹", ukElectronVolt, power = -1 * b.power, b.siPrefix, factor = some(6.5821220e-16))
   of buAmpere:
     result = initCTUnit("eV", ukElectronVolt, power = 1 * b.power, b.siPrefix, factor = some(0.00080381671))
-  of buKelvin: error("Broken")
+  of buKelvin:
+    result = initCTUnit("eV", ukElectronVolt, power = 1 * b.power, b.siPrefix, factor = some(11604.518))
   of buMol:
     result = initCTUnit("", ukUnitLess, power = 1 * b.power, b.siPrefix, factor = some(1.0))
   of buCandela: error("Broken")


### PR DESCRIPTION
See the full changelog:

```
* v0.1.10
  - =defUnits= now has an =export= option to define a unit that is
    exported (therefore this =defUnit= can only be used at top level!)
  - add =Gauss= as a unit
  - allow conversion of =Kelvin= to natural units
  - allow units with `·` instead of `•`
    Note: this is only for units that user *hands and constructs
    themselves*. Predefined units or those auto generated when by `*` and
    similar still concat units using `•`. So YMMV and all that, but it
    opens up the possibility of being more flexible in the future.
  - add constant =m_u=, defined by =M_u / N_A=
  - rename Boltzmann constant from =k= to =k_B=
  - add =pretty= for units that allows a =short= parameter. That way the
    unit will be string converted to a name with the short unit naming,
    i.e. m•s⁻¹ instead of Meter•Second⁻¹. For now the default will
    remain the long version, but that may change in the future.
```