### PR TITLE
Fix type information loss with `const` variable, fixes #5

### DIFF
--- a/src/unchained/constants.nim
+++ b/src/unchained/constants.nim
@@ -4,7 +4,7 @@ import si_units, units
 ## A (so far small) set of (mostly physics related) constants defined
 ## in the units of Unchained.
 
-let
+const
   c* = 299792458.0.Meter•Second⁻¹
   ε_0* = 8.8541878128e-12.A•s•V⁻¹•m⁻¹
   e* = 1.602176634e-19.C

--- a/src/unchained/macro_utils.nim
+++ b/src/unchained/macro_utils.nim
@@ -88,12 +88,13 @@ proc getUnitType*(n: NimNode): NimNode =
 
 proc isUnitLessNumber*(n: NimNode): bool =
   case n.kind
-  of nnkIntLit .. nnkFloatLit: result = true
   of nnkIdent: result = false # most likely direct unit
   of nnkAccQuoted:
     ## TODO: disallow things that are not a number?
     result = false
   else:
+    ## NOTE: We cannot check for intLit / floatLit etc, as a `const` variable that
+    ## has a unit will still be treated as a literal!
     let nTyp = n.getTypeInst
     if nTyp.kind == nnkSym:
       ## TODO: improve this check / include other numeric types

--- a/tests/tunchained.nim
+++ b/tests/tunchained.nim
@@ -802,6 +802,13 @@ suite "Unchained - Bug issues":
       result = E.to(Joule) / hp
     check 1.keV.xrayEnergyToFreq =~= 2.41799e17.Hz
 
+  test "Math with unitful `const` variables works":
+    ## this was previously broken, issue #5. The unit was dropped when parsing
+    ## the unit, as the `isUnitLessNumber` check returned `true` for `const` values
+    const g_aγ = 1e-10.GeV⁻¹
+    let x = g_aγ * 1.0.eV²
+    check typeof(x) is ElectronVolt
+    check x =~= 1e-19.eV
 
 #converter to_eV(x: GeV): eV =
 #  echo "toEv!"


### PR DESCRIPTION
Finally fixes the underlying issue of #5. The problem was simply that our quick check if the input is `UnitLess` was flawed for `const` variables, as their node kind is still an `nnkFloatLit`.