### PR TITLE
Fix signature of `to` procedure

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,5 @@
+* v0.2.2
+- fix =to= to explicitly only work with =SomeUnit= types
 * v0.2.1
 - fix underlying issue of #5, the loss of type information when using
   unitful =const= variables in unit math. The issue was our

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -402,7 +402,7 @@ macro determineScale(x: typedesc, y: typedesc): float =
   let yScale = yCT.toBaseTypeScale()
   result = newLit(xScale / yScale)
 
-proc to*[T; U](x: T, to: typedesc[U]): U =
+proc to*[T: SomeUnit; U: SomeUnit](x: T, to: typedesc[U]): U =
   ## TODO: replace by macro as well so that we can deal with arbitrary types
   ##
   ## check if conversion possible


### PR DESCRIPTION
The generics of the `to` procedure were unconstrained. Matched also types that it shouldn't resulting in an (almost) endless loop.