### PR TITLE
Fix missing conversions between base and derived units

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,7 @@
+* v0.2.4
+- fix regression #29, multiplication / division between base and
+  derived units (e.g. SI and an imperial) did not convert, even if
+  they shared a common quantity
 * v0.2.3
 - fix resolving =ntyGenericInst= (which also effectively handles
   =ntySequence= it seems)

--- a/src/unchained/define_units.nim
+++ b/src/unchained/define_units.nim
@@ -213,7 +213,13 @@ proc toBaseType*(u: UnitInstance, needConversion: bool): UnitProduct =
       result.units.add mu
     of utDerived:
       # result is simply the conversion (factor + unit) of this derived unit
-      result = u.unit.conversion
+      result = newUnitProduct(u.unit.conversion.value)
+      # starting from a new unit product (as it's a ref) and apply powers of `u` to each
+      # base unit of the converted unit.
+      for bu in u.unit.conversion.units:
+        var mbu = bu
+        mbu.power *= u.power
+        result.units.add mbu
       # now add possible further prefixes / powers of the input
       result.value *= pow(u.prefix.toFactor(), u.power.float) # XXX: * u.value ? we don't use `value` atm
 

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -316,7 +316,11 @@ macro `*`*[T: SomeUnit|SomeNumber; U: SomeUnit|SomeNumber](x: T; y: U): untyped 
     let scaleOriginal = xCT.toBaseTypeScale()
     # and flatten if needed
     xCT = xCT.flatten(needConversion)
-    var resTypeCT = xCT.simplify(mergePrefixes = true)
+    var resTypeCT: UnitProduct
+    if needConversion:
+      resTypeCT = xCT.toBaseType(needConversion).simplify(mergePrefixes = true)
+    else:
+      resTypeCT = xCT.simplify(mergePrefixes = true)
     # determine scale of resulting units
     let scaleConv = resTypeCT.toBaseTypeScale() ## WRONG: must not *always* call conversion
     let resType = resTypeCT.simplify().toNimType()
@@ -352,7 +356,11 @@ macro `/`*[T: SomeUnit|SomeNumber; U: SomeUnit|SomeNumber](x: T; y: U): untyped 
     let scaleOriginal = xCT.toBaseTypeScale()
 
     xCT = xCT.flatten(needConversion)
-    var resTypeCT = xCT.simplify(mergePrefixes = true)
+    var resTypeCT: UnitProduct
+    if needConversion:
+      resTypeCT = xCT.toBaseType(needConversion).simplify(mergePrefixes = true)
+    else:
+      resTypeCT = xCT.simplify(mergePrefixes = true)
     let scaleConv = resTypeCT.toBaseTypeScale()
     let resType = resTypeCT.simplify().toNimType()
     if scaleOriginal != scaleConv:

--- a/tests/tunchained.nim
+++ b/tests/tunchained.nim
@@ -709,6 +709,18 @@ suite "Unchained - imperial units":
       let y = 1.Meter
       check type(x + y) is Meter
       check x + y =~= 1.3048.Meter
+    block Multiply:
+      let x = 5.m
+      let y = 3.ft⁻¹
+      check x * y =~= 49.2126.UnitLess
+      check typeof(x * y) is UnitLess
+    block Divide:
+      let x = 15.m
+      let y = 5.m.to(ft)
+      check typeof(y) is Foot
+      check x / y =~= 3.UnitLess
+      check typeof(x / y) is UnitLess
+
 
   test "Yard":
     block:


### PR DESCRIPTION
Fixes issue #29, which appeared because we lacked a single test that combines an SI and an imperial unit under `*` or `/`.