### PR TITLE
Improve custom `^` macro 

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,8 +1,10 @@
 * v0.2.5
 - improve `^` handling for static integers (powers smaller 2 now
   supported as well as negative powers)
-- allow to print unit names without unicode half width space, if
-  compiled with `-d:noUnicode`.   
+- allow to print unit names without unicode half width space and no
+  unicode symbols in unit names, if compiled with `-d:noUnicode`.
+- *BREAKING*: changes the default behavior of printing unitful
+  variables from long format to short format!
 * v0.2.4
 - fix regression #29, multiplication / division between base and
   derived units (e.g. SI and an imperial) did not convert, even if

--- a/changelog.org
+++ b/changelog.org
@@ -5,6 +5,8 @@
   unicode symbols in unit names, if compiled with `-d:noUnicode`.
 - *BREAKING*: changes the default behavior of printing unitful
   variables from long format to short format!
+  - to change the behavior you can either call ~pretty~ manually and
+    hand ~short = false~ or compile with ~-d:ShortFormat=false~.
 * v0.2.4
 - fix regression #29, multiplication / division between base and
   derived units (e.g. SI and an imperial) did not convert, even if

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,8 @@
+* v0.2.5
+- improve `^` handling for static integers (powers smaller 2 now
+  supported as well as negative powers)
+- allow to print unit names without unicode half width space, if
+  compiled with `-d:noUnicode`.   
 * v0.2.4
 - fix regression #29, multiplication / division between base and
   derived units (e.g. SI and an imperial) did not convert, even if

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -102,10 +102,10 @@ proc pretty*[T: SomeUnit](s: T, precision: int, short: bool): string =
   result.trimZeros()
   if not short:
     let typStr = unitName(T)
-    result.add &" {typStr}"
+    result.add &" {typStr}"
   else:
     let typStr = shortName(T)
-    result.add &" {typStr}"
+    result.add &" {typStr}"
 
 proc `$`*[T: SomeUnit](s: T): string = pretty(s, precision = -1, short = false)
 

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -113,7 +113,7 @@ proc pretty*[T: SomeUnit](s: T, precision: int, short: bool): string =
     else:
       result.add &" {typStr}"
 
-proc `$`*[T: SomeUnit](s: T): string = pretty(s, precision = -1, short = false)
+proc `$`*[T: SomeUnit](s: T): string = pretty(s, precision = -1, short = true)
 
 macro defUnit*(arg: untyped, toExport: bool = false): untyped =
   ## Helper template to define new units (not required to be used manually)

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -3,8 +3,8 @@ import math, macros, options, sets, tables, strutils, unicode, typetraits, strfo
 ## This file is the main user facing API
 import core_types, ct_unit_types, macro_utils, define_units, quantities
 
-proc pretty(x: UnitInstance, short = false): string = x.toNimType(short)
-proc pretty(x: UnitProduct, short = false): string = x.toNimTypeStr(short)
+proc pretty(x: UnitInstance, short = true): string = x.toNimType(short, internal = false)
+proc pretty(x: UnitProduct, short = true): string = x.toNimTypeStr(short, internal = false)
 
 macro quantityList*(): untyped =
   result = nnkBracket.newTree()

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -102,10 +102,16 @@ proc pretty*[T: SomeUnit](s: T, precision: int, short: bool): string =
   result.trimZeros()
   if not short:
     let typStr = unitName(T)
-    result.add &" {typStr}"
+    when not defined(noUnicode):
+      result.add &" {typStr}"
+    else:
+      result.add &" {typStr}"
   else:
     let typStr = shortName(T)
-    result.add &" {typStr}"
+    when not defined(noUnicode):
+      result.add &" {typStr}"
+    else:
+      result.add &" {typStr}"
 
 proc `$`*[T: SomeUnit](s: T): string = pretty(s, precision = -1, short = false)
 

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -3,6 +3,8 @@ import math, macros, options, sets, tables, strutils, unicode, typetraits, strfo
 ## This file is the main user facing API
 import core_types, ct_unit_types, macro_utils, define_units, quantities
 
+const ShortFormat {.booldefine.} = true
+
 proc pretty(x: UnitInstance, short = true): string = x.toNimType(short, internal = false)
 proc pretty(x: UnitProduct, short = true): string = x.toNimTypeStr(short, internal = false)
 
@@ -113,7 +115,7 @@ proc pretty*[T: SomeUnit](s: T, precision: int, short: bool): string =
     else:
       result.add &" {typStr}"
 
-proc `$`*[T: SomeUnit](s: T): string = pretty(s, precision = -1, short = true)
+proc `$`*[T: SomeUnit](s: T): string = pretty(s, precision = -1, short = ShortFormat)
 
 macro defUnit*(arg: untyped, toExport: bool = false): untyped =
   ## Helper template to define new units (not required to be used manually)

--- a/src/unchained/utils.nim
+++ b/src/unchained/utils.nim
@@ -8,7 +8,7 @@ macro `^`*(x: typed, num: static int): untyped =
   ## result. Negative powers are written as `1 / x^p`
   if num == 0:
     result = quote do:
-      `x` * typeof(`x`)(0.0)
+      1.0
   elif num == 1:
     result = x
   elif num == -1:

--- a/src/unchained/utils.nim
+++ b/src/unchained/utils.nim
@@ -1,16 +1,35 @@
 import std / [macros]
 
-macro `^`*(x: untyped, num: static int): untyped =
+macro `^`*(x: typed, num: static int): untyped =
   ## general purpose power using `^` for integers, which works for any
   ## type by rewriting to a product of `*`.
-  result = nnkInfix.newTree(ident"*")
+  ##
+  ## For the special cases of -1, 0, 1 we simply rewrite to the correct
+  ## result. Negative powers are written as `1 / x^p`
+  if num == 0:
+    result = quote do:
+      `x` * typeof(`x`)(0.0)
+  elif num == 1:
+    result = x
+  elif num == -1:
+    ## Assume that the type supports addition by a float!
+    result = quote do:
+      1.0 / `x`
+  else:
+    result = nnkInfix.newTree(ident"*")
 
-  proc addInfix(n, x: NimNode, num: int) =
-    var it = n
-    if num > 0:
-      it.add nnkInfix.newTree(ident"*")
-      it[1].addInfix(x, num - 1)
-    while it.len < 3:
-      it.add x
+    proc addInfix(n, x: NimNode, num: int) =
+      var it = n
+      if num > 0:
+        it.add nnkInfix.newTree(ident"*")
+        it[1].addInfix(x, num - 1)
+      while it.len < 3:
+        it.add x
 
-  result.addInfix(x, num - 2)
+    result.addInfix(x, abs(num) - 2)
+
+    # invert if num is negative
+    if num < -1:
+      ## Assume that the type supports addition by a float!
+      result = quote do:
+        1.0 / (`result`)

--- a/tests/tunchained.nim
+++ b/tests/tunchained.nim
@@ -834,6 +834,35 @@ suite "Unchained - Bug issues":
       b = 5.m•s⁻¹
     check a * b == @[5.m•s⁻¹, 10.m•s⁻¹, 15.m•s⁻¹]
 
+suite "Utils":
+  test "Power w/ static integer exponents for floats":
+    let x = 5
+    check x ^ 0  == 1.0
+    check x ^ 1  == x
+    check x ^ 2  == x * x
+    check x ^ 3  == x * x * x
+    check x ^ 4  == x * x * x * x
+    check x ^ 5  == x * x * x * x * x
+    check x ^ -1 == 1 / x
+    check x ^ -2 == 1 / (x * x)
+    check x ^ -3 == 1 / (x * x * x)
+    check x ^ -4 == 1 / (x * x * x * x)
+    check x ^ -5 == 1 / (x * x * x * x * x)
+
+  test "Power w/ static integer exponents for units":
+    let x = 5.kg
+    check x ^ 0  == 1.0
+    check x ^ 1  == x
+    check x ^ 2  == x * x
+    check x ^ 3  == x * x * x
+    check x ^ 4  == x * x * x * x
+    check x ^ 5  == x * x * x * x * x
+    check x ^ -1 == 1 / x
+    check x ^ -2 == 1 / (x * x)
+    check x ^ -3 == 1 / (x * x * x)
+    check x ^ -4 == 1 / (x * x * x * x)
+    check x ^ -5 == 1 / (x * x * x * x * x)
+
 
 #converter to_eV(x: GeV): eV =
 #  echo "toEv!"


### PR DESCRIPTION
Previously this macro was a bit too dumb and only worked for powers `>= 2`. For smaller and negative values it produced rubbish.

edit: 
Also makes the string representation use a half-width space between number and unit by default. Can be disabled by compiling with `-d:noUnicode`, which also disables usage of unicode in the printing of the unit names.

Finally, changes the default behavior of unit printing from long format to short format for more concise output.
Use `pretty` manually to hand `short = false` if the previous behavior was preferred or compile with `-d:ShortFormat=false`.