### PR TITLE
Add quantity concepts

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,22 +7,89 @@ based code (aside from insertion of possible conversion factors, but
 those would have to be written by hand otherwise of course).
 
 It supports:
-- all base SI units
+- all base SI units and (most) compound SI units
+- units as short and long name:
+  #+begin_src nim
+import unchained
+let x = 10.m
+let y = 10.Meter
+doAssert x == y
+  #+end_src
 - some imperial units
 - all SI prefixes
+  #+begin_src nim
+import unchained
+let x = 10.Mm # mega meter
+let y = 5.ng # nano gram
+let z = 10.aT # atto tesla 
+  #+end_src
 - arbitrary math with units composing to new units, e.g. (which do not have
-  to be defined previously!), e.g. =10.m * 10.m * 10.m * 10.m * 10.m=
+  to be defined previously!),
+  #+begin_src nim
+import unchained
+let x = 10.m * 10.m * 10.m * 10.m * 10.m
+doAssert typeof(x) is Meter⁵
+  #+end_src
   without having to predefine a =Meter⁵= type
 - automatic conversion between SI prefixes if a mix is used
+  #+begin_src nim
+import unchained
+let x = 5.kg + 5.lbs
+doAssert typeof(x) is kg
+doAssert x == 7.26796.kg
+  #+end_src
+- manual conversion of units to compatible other units via ~to~
+  (e.g. 
+  #+begin_src nim
+import unchained
+let x = 5.m•s⁻¹
+defUnit(km•h⁻¹) # needs to be defined to be able to convert to
+                # `to` could be a macro that defines it for us 
+doAssert x.to(km•h⁻¹) == 18.km•h⁻¹
+# the `toDef` macro can be used to both define and convert a unit,
+# but under certain use cases it can break (see its documentation)
+  #+end_src
+- comparisons between units compare real value taking into account SI
+  prefixes and even different units of the same quantity:  
+#+begin_src nim
+import unchained
+let x = 10.Mm # mega meter
+doAssert x == 10_000_000.m
+let y = 5.ng # nano gram
+doAssert y == 5e-9.g
+let z = 10.aT # atto tesla
+doAssert z == 10e-18.T
+# and even different units of same quantity
+let a = 5000.inch•s⁻¹
+let b = a.toDef(km•h⁻¹) # defines the unit and convers `a` to it
+doAssert b == 457.2.km•h⁻¹
+doAssert typeof(a) is inch•s⁻¹ # SI units have higher precedence than non SI
+doAssert typeof(b) is km•h⁻¹
+doAssert a == b # comparison is true, as the effective value is the same!
+#+end_src
+  Note: comparison between units is performed using an ~almostEqual~
+  implementation. By default it uses ~ε = 1e-8~. The power can be
+  changed at CT by using the ~-d:UnitCompareEpsilon=<integer>~ where
+  the given integer is the negative power used.
+- all quantities (e.g. ~Length~, ~Mass~, ...) defined as a ~concept~
+  to allow matching different units of same quantity in function
+  argument
+  #+begin_src nim
+import unchained
+proc force[M: Mass, A: Acceleration](m: M, a: A): Force = m * a
+let m = 80.kg
+let g = 9.81.m•s⁻²
+let f = force(m, g)
+doAssert typeof(f) is Newton
+doAssert f == 784.8000000000001.N
+  #+end_src
+- define your own custom unit systems, see [[examples/custom_unit_system.nim]]  
 - ...
 
-Aside from bugs and polish the main thing missing is proper handling
-of natural units (they exist, but are untested and their unit in terms
-of =eV= is not implemented).
-
-In no particular order things that either are or need to be supported:
+A longer snippet showing different features below. See also
+[[examples/bethe_bloch.nim]] for a more complicated use case.
 #+begin_src nim
-## The following already work unless `TODO` (not all units implemented)
+import unchained
 block:
   # defining simple units
   let mass = 5.kg
@@ -31,33 +98,34 @@ block:
   # addition and subtraction of same units
   let a = 5.kg
   let b = 10.kg
-  check typeof(a + b) is KiloGram
-  check a + b == 15.kg
-  check typeof(a - b) is KiloGram
-  check a - b == 15.kg
+  doAssert typeof(a + b) is KiloGram
+  doAssert a + b == 15.kg
+  doAssert typeof(a - b) is KiloGram
+  doAssert a - b == -5.kg
 block:
   # addition and subtraction of units of the same ``quantity`` but different scale
   let a = 5.kg
   let b = 500.g
-  check typeof(a + b) is KiloGram
-  check a + b == 5.5.kg
+  doAssert typeof(a + b) is KiloGram
+  doAssert a + b == 5.5.kg
   # if units do not match, the SI unit is used!
 block:
   # product of prefixed SI unit keeps same prefix unless multiple units of same quantity involved
   let a = 1.m•s⁻²
   let b = 500.g
-  check typeof(a * b) is Gram•Meter•Second⁻²
-  check typeof(a * b) is MilliNewton
-  check a * b == 500.g•m•s⁻²
+  doAssert typeof(a * b) is Gram•Meter•Second⁻²
+  doAssert typeof((a * b).to(MilliNewton)) is MilliNewton
+  doAssert a * b == 500.g•m•s⁻²
 block:
   let mass = 5.kg
   let a = 9.81.m•s⁻²
   # unit multiplication has to be commutative
   let F: Newton = mass * a
-  let F2: Newton = a * mass # TODO
+  let F2: Newton = a * mass
   # unit division works as expected
-  check typeof(F / mass) is Meter•Second⁻²
-  check F / mass == a
+  doAssert typeof(F / mass) is N•kg⁻¹
+  doAssert typeof((F / mass).to(Meter•Second⁻²)) is Meter•Second⁻²
+  doAssert F / mass == a
 block:
   # automatic deduction of compound units for simple cases
   let force = 1.kg * 1.m * 1.s⁻²
@@ -66,13 +134,14 @@ block:
 block:
   # conversion between units of the same quantity
   let f = 10.N
-  check typeof(f.to(kN)) is KiloNewton
-  check f.to(kN) == 0.01.kN
+  doAssert typeof(f.to(kN)) is KiloNewton
+  doAssert f.to(kN) == 0.01.kN
 block:
   # pre-defined physical constants
   let E_e⁻_rest: Joule = m_e * c*c # math operations `*cannot*` use superscripts!
   # m_e = electron mass in kg
   # c = speed of light in vacuum in m/s
+from std/math import sin  
 block:
   # automatic CT error if argument of e.g. sin, ln are not unit less
   let x = 5.kg
@@ -88,23 +157,15 @@ block:
   # mixing of non SI and SI units (via conversion to SI units)
   let m1 = 100.lbs
   let m2 = 10.kg
-  check typeof(m1 + m2) is KiloGram
-  check m1 + m2 == 55.3592.KiloGram
+  doAssert typeof(m1 + m2) is KiloGram
+  doAssert m1 + m2 == 55.359237.KiloGram
 block:
   # natural unit conversions
   let speed = (0.1 * c).toNaturalUnit() # fraction of c, defined in `constants`
   let m_e = 9.1093837015e-31.kg.toNaturalUnit()
   # math between natural units remains natural
   let p = speed * m_e # result will be in `eV`
-  check p.to(keV) == 51.1.keV
-block:
-  # auto conversion of natural units
-  let a = 10.MeV
-  let b = 200.eV
-  check typeof(a / b) is UnitLess # `UnitLess` is 
-  check a / b == 50_000.Unitless
-
-  
+  doAssert p.to(keV) == 51.099874.keV
 
 ## If there is demand the following kind of syntax may be implemented in the future
 when false:
@@ -119,27 +180,27 @@ when false:
 
 Things to note:
 - real units use capital letters and are verbose
-- shorthands defined for all typical units
+- shorthands defined for all typical units using their common
+  abbreviation (upper or lower case depending on the unit, e.g. ~s~ (second)
+  and ~N~ (Newton)
 - conversion of numbers to units done using `.` call and using
   shorthand names  
 - `•` symbol is product of units to allow unambiguous parsing of units
+  -> specific unicode symbol may become user customizable in the future
 - no division of units, but negative exponents
 - exponents are in superscript
 - usage of `•` and superscript is to circumvent Nim's identifier
   rules!
 - SI units are the base. If ambiguous operation that can be solved by
-  unit conversion, SI units are used.  
+  unit conversion, SI units are used (in the default SI unit system
+  predefined when simply importing ~unchained~)
 - math operations *cannot* use superscripts!
-- physical units are defined
+- some physical constants are defined, more likely in the future 
 - conversion from prefixed SI unit to non prefixed SI unit *only*
   happens if multiple prefixed units of same quantity involved
 - =UnitLess= is a =distinct float= unit that has a converter to
   =float= (such that =UnitLess= magically works with math functions
   expecting floats).
-- type comparison with =is= is somewhat broken, because it checks for
-  explicit equalness, but not up aliases. Due to that reason we will
-  provide a custom =is= operator that perform type equality checks in
-  the same way as it is done for ~==~.
 
 ** Why "Unchained"?
 Un = Unit

--- a/README.org
+++ b/README.org
@@ -81,7 +81,7 @@ let m = 80.kg
 let g = 9.81.m•s⁻²
 let f = force(m, g)
 doAssert typeof(f) is Newton
-doAssert f == 784.8000000000001.N
+doAssert f == 784.8.N
   #+end_src
 - define your own custom unit systems, see [[examples/custom_unit_system.nim]]  
 - ...

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,15 @@
+* v0.3.0
+- concepts for each quantity to match different units of same quantity
+  in procedure calls!
+- ~<~ for CT units now sorts positive powers before negative, this can
+  be a *breaking* change
+- in `.` define the resulting type based on what's given, not
+  simplified, this can be a *breaking* change
+- add ~toDef~ to combine the usage of ~defUnit~ with ~to~ (this can be
+  problematic, see docstring)
+- clean up ~defUnit~ and also always generate the short name version
+  of a given unit
+- update README
 * v0.2.5
 - improve `^` handling for static integers (powers smaller 2 now
   supported as well as negative powers)

--- a/src/unchained/api.nim
+++ b/src/unchained/api.nim
@@ -13,3 +13,6 @@ import unchained / [utils, core_types, units]
 export core_types
 export units
 export utils
+
+from unchained / define_units import isAUnit
+export isAUnit

--- a/src/unchained/define_units.nim
+++ b/src/unchained/define_units.nim
@@ -764,7 +764,7 @@ macro isAUnit*(x: typed): untyped =
 
 macro isQuantity*(x: typed, quant: typed): untyped =
   ## Checks if `x` (a unit) is the same quantity as `quant`
-  doAssert quant.kind in {nnkSym, nnkIdent}
+  doAssert quant.kind == nnkStrLit
   let q = QuantityTab[quant.strVal]
   result = newLit commonQuantity(x.parseDefinedUnit(), q)
 
@@ -782,8 +782,8 @@ macro generateQuantityConcepts*(): untyped =
   ## the defined quantity (and does not refer to the concept itself!)
   result = newStmtList()
   for k, v in QuantityTab:
-    let quantName = ident(k)
-    let conceptName = nnkPostfix.newTree(ident"*", quantName)
+    let quantName = k
+    let conceptName = nnkPostfix.newTree(ident"*", ident(quantName))
     result.add quote do:
       type
         `conceptName` = concept x

--- a/src/unchained/define_units.nim
+++ b/src/unchained/define_units.nim
@@ -24,6 +24,15 @@ proc parseDefinedUnit*(x: NimNode): UnitProduct =
 
 proc `<`*(a, b: UnitInstance): bool =
   ## Comparison based on the order in `UnitTab`.
+  # 1. check if one is positive power and other negative,
+  # if so return early and ignore actual units (so that
+  # `inch•s⁻¹` remains this order, desipte lower precedence of
+  # `inch` compared to `s`
+  if a.power > 0 and b.power < 0:
+    return true
+  elif b.power > 0 and a.power < 0:
+    return false
+  # 2. if not returned take unit precedence into account
   let aIdx = UnitTab.getIdx(a)
   let bIdx = UnitTab.getIdx(b)
   if aIdx < bIdx:

--- a/src/unchained/macro_utils.nim
+++ b/src/unchained/macro_utils.nim
@@ -78,6 +78,26 @@ proc getUnitTypeImpl*(n: NimNode): NimNode =
   of ntyDistinct: result = n.resolveTypeFromDistinct()
   of ntyTypeDesc: result = n.resolveTypeFromTypeDesc()
   of ntyGenericInst: result = n.resolveTypeFromGenericInst()
+  of ntyUserTypeClass:
+    ## NOTE: Attempting to resolve a type from such an implicit generic doesn't
+    ## work properly. See tests/tResolveImplicitQuantity.nim
+    ## for a case in which no `getType*` yields anything useful.
+    error("""Cannot get a type from a `ntyUserTypeClass`. You are likely using a quantity concept as a generic argument directly, instead of using an explicit generic. Replace usage of the kind
+
+    ```nim
+    proc foo(x: Length)
+    ```
+
+    by
+
+    ```nim
+    proc foo[T: Length](x: T)
+    ```
+
+    as currently we cannot reliably extract the real type of `Length` in the former case.
+    If your problem is a different one, please open an issue at:
+    https://github.com/SciNim/unchained
+""")
   else: error("Unsupported : " & $n.typeKind)
 
 proc getUnitType*(n: NimNode): NimNode =

--- a/src/unchained/quantities.nim
+++ b/src/unchained/quantities.nim
@@ -24,7 +24,6 @@ type
       name*: string # name of the derived quantity (e.g. Force)
       baseSeq*: seq[QuantityPower]
 
-
 proc `==`*(q1, q2: CTBaseQuantity): bool = q1.name == q2.name
 proc `<`*(q1, q2: CTBaseQuantity): bool = q1.name < q2.name
 
@@ -86,10 +85,12 @@ proc `==`*(q1, q2: CTQuantity): bool =
 proc contains*(s: HashSet[CTBaseQuantity], key: string): bool =
   result = CTBaseQuantity(name: key) in s
 
-proc getName*(q: CTQuantity): string =
+proc getName*(q: CTQuantity, typeName: bool = false): string =
+  ## Suffix `QT` == `QuantityType`
+  let suffix = if typeName: "QT" else: ""
   case q.kind
-  of qtFundamental: result = q.b.name
-  of qtCompound: result = q.name
+  of qtFundamental: result = q.b.name & suffix
+  of qtCompound: result = q.name & suffix
 
 proc reduce(s: seq[QuantityPower]): seq[QuantityPower] =
   ## Reduces possible duplicate units with different powers.
@@ -215,7 +216,7 @@ proc genQuantityTypes*(quants: seq[CTQuantity], qType: QuantityType): NimNode =
                 "CompoundQuantity"
               else:
                 "UnitLess"
-    let qName = quant.getName()
+    let qName = quant.getName(typeName = true)
     result.add defineDistinctType(qName, q)
     quantList.add ident(qName)
   let qtc = case qType
@@ -230,10 +231,10 @@ proc genQuantityKindEnum*(base, derived: seq[CTQuantity]): NimNode =
     ident"qkUnitLess" # UnitLess quantity kind must be first element
   )
   for b in base:
-    let bName = b.getName()
+    let bName = b.getName(typeName = true)
     en.add nnkEnumFieldDef.newTree(ident("qk" & bName), newLit bName)
   for d in derived:
-    let dName = d.getName()
+    let dName = d.getName(typeName = true)
     en.add nnkEnumFieldDef.newTree(ident("qk" & dName), newLit dName)
   result.add en
   result = nnkTypeSection.newTree(result)

--- a/src/unchained/si_units.nim
+++ b/src/unchained/si_units.nim
@@ -38,6 +38,9 @@ declareQuantities:
     Activity:              [(Time, -1)]
     AreaDensity:           [(Length, -2), (Mass, 1)]
 
+# generate the concepts for the quantities to use them as types in procedures
+generateQuantityConcepts()
+
 ## Define units is imported only *after* the quantities are declared!
 #import define_units
 export define_units.commonQuantity

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -8,39 +8,6 @@ const ShortFormat {.booldefine.} = true
 proc pretty(x: UnitInstance, short = true): string = x.toNimType(short, internal = false)
 proc pretty(x: UnitProduct, short = true): string = x.toNimTypeStr(short, internal = false)
 
-macro quantityList*(): untyped =
-  result = nnkBracket.newTree()
-  result.add newLit"Quantity"
-  result.add newLit"CompoundQuantity"
-  result.add newLit"Unit"
-  result.add newLit"Quantity"
-  result.add newLit"SiUnit"
-  result.add newLit"DerivedSiUnits"
-  result.add newLit"SomeQuantity"
-  result.add newLit"DerivedQuantity"
-  result.add newLit"BaseQuantity"
-
-macro isAUnit*(x: typed): untyped =
-  ## NOTE: it's really hard to replace this by something cleaner :/
-  ## Ideally this should be replaced by something that uses shared logic with
-  ## `getUnitTypeImpl` & making use of CT tables (possibly of objects?)
-  let x = x.resolveAlias()
-  case x.kind
-  of nnkSym, nnkDistinctTy:
-    let typ = x
-    var xT = if typ.kind == nnkDistinctTy: typ[0] else: typ
-    while xT.strVal notin quantityList():
-      xT = xT.getTypeImpl
-      case xT.kind
-      of nnkDistinctTy:
-        xT = xT[0]
-      else:
-        return newLit false
-  else:
-    return newLit false
-  ## in this case investigation is true
-  result = newLit true
-
 ## The main concept used for type matching of units
 type
   SomeUnit* = concept x

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -129,12 +129,13 @@ macro defUnit*(arg: untyped, toExport: bool = false): untyped =
             type `arg`* = distinct CompoundQuantity
 
 ## TODO: we should really combine these macros somewhat?
+from utils import almostEqual
 macro `==`*[T: SomeUnit; U: SomeUnit](x: T, y: U): bool =
   var xCT = parseDefinedUnit(x)
   var yCT = parseDefinedUnit(y)
   if xCT == yCT:
     result = quote do:
-      (`x`.float == `y`.float)
+      almostEqual(`x`.float, `y`.float)
   elif xCT.commonQuantity(yCT):
     # is there a scale difference between the two types?
     let xScale = xCT.toBaseTypeScale()
@@ -147,7 +148,7 @@ macro `==`*[T: SomeUnit; U: SomeUnit](x: T, y: U): bool =
     # compare scaled to base type units
     ## TODO: use almostEqual?
     result = quote do:
-      (`x`.float * `xScale` == `y`.float * `yScale`)
+      almostEqual(`x`.float * `xScale`, `y`.float * `yScale`)
   else:
     error("Different quantities cannot be compared! Quantity 1: " & (x.getTypeInst).repr & ", Quantity 2: " & (y.getTypeInst).repr)
 

--- a/tests/tresolveAlias.nim
+++ b/tests/tresolveAlias.nim
@@ -20,40 +20,40 @@ suite "Resolve valid units":
   checkUnit(UnitLess)
 
   ## Base Quantities
-  checkUnit(Time)
-  checkUnit(Length)
-  checkUnit(Mass)
-  checkUnit(Current)
-  checkUnit(Temperature)
-  checkUnit(AmountOfSubstance)
-  checkUnit(Luminosity)
+  checkUnit(TimeQT)
+  checkUnit(LengthQT)
+  checkUnit(MassQT)
+  checkUnit(CurrentQT)
+  checkUnit(TemperatureQT)
+  checkUnit(AmountOfSubstanceQT)
+  checkUnit(LuminosityQT)
 
   checkUnit(BaseQuantity)
 
   ## Derived quantities, TODO: should be `distinct CompoundQuantity`? Not a single dimension!
-  checkUnit(Velocity)
-  checkUnit(Acceleration)
-  checkUnit(Momentum)
-  checkUnit(Force)
-  checkUnit(Energy)
-  checkUnit(Density)
+  checkUnit(VelocityQT)
+  checkUnit(AccelerationQT)
+  checkUnit(MomentumQT)
+  checkUnit(ForceQT)
+  checkUnit(EnergyQT)
+  checkUnit(DensityQT)
 
-  checkUnit(ElectricPotential)
+  checkUnit(ElectricPotentialQT)
   # Since declarative quantity def currently not defined
-  # checkUnit(Voltage)
+  # checkUnit(VoltageQT)
 
-  checkUnit(Frequency)
+  checkUnit(FrequencyQT)
 
-  checkUnit(Charge)
-  checkUnit(Power)
-  checkUnit(ElectricResistance)
-  checkUnit(Capacitance)
-  checkUnit(Inductance)
-  checkUnit(Pressure)
+  checkUnit(ChargeQT)
+  checkUnit(PowerQT)
+  checkUnit(ElectricResistanceQT)
+  checkUnit(CapacitanceQT)
+  checkUnit(InductanceQT)
+  checkUnit(PressureQT)
 
   # angles and solid angles are technically UnitLess.
-  checkUnit(Angle)
-  checkUnit(SolidAngle)
+  checkUnit(AngleQT)
+  checkUnit(SolidAngleQT)
 
   checkUnit(DerivedQuantity)
 
@@ -184,37 +184,37 @@ suite "Valid unit-ful values":
     wrapFoo(UnitLess)
 
     ## Base Quantities
-    wrapFoo(Time)
-    wrapFoo(Length)
-    wrapFoo(Mass)
-    wrapFoo(Current)
-    wrapFoo(Temperature)
-    wrapFoo(AmountOfSubstance)
-    wrapFoo(Luminosity)
+    wrapFoo(TimeQT)
+    wrapFoo(LengthQT)
+    wrapFoo(MassQT)
+    wrapFoo(CurrentQT)
+    wrapFoo(TemperatureQT)
+    wrapFoo(AmountOfSubstanceQT)
+    wrapFoo(LuminosityQT)
 
     ## Derived quantities, TODO: should be `distinct CompoundQuantity`? Not a single dimension!
-    wrapFoo(Velocity)
-    wrapFoo(Acceleration)
-    wrapFoo(Momentum)
-    wrapFoo(Force)
-    wrapFoo(Energy)
-    wrapFoo(Density)
+    wrapFoo(VelocityQT)
+    wrapFoo(AccelerationQT)
+    wrapFoo(MomentumQT)
+    wrapFoo(ForceQT)
+    wrapFoo(EnergyQT)
+    wrapFoo(DensityQT)
 
-    wrapFoo(ElectricPotential)
-    #wrapFoo(Voltage)
+    wrapFoo(ElectricPotentialQT)
+    #wrapFoo(VoltageQT)
 
-    wrapFoo(Frequency)
+    wrapFoo(FrequencyQT)
 
-    wrapFoo(Charge)
-    wrapFoo(Power)
-    wrapFoo(ElectricResistance)
-    wrapFoo(Capacitance)
-    wrapFoo(Inductance)
-    wrapFoo(Pressure)
+    wrapFoo(ChargeQT)
+    wrapFoo(PowerQT)
+    wrapFoo(ElectricResistanceQT)
+    wrapFoo(CapacitanceQT)
+    wrapFoo(InductanceQT)
+    wrapFoo(PressureQT)
 
     #  angles are technically UnitLess.
-    wrapFoo(Angle)
-    wrapFoo(SolidAngle)
+    wrapFoo(AngleQT)
+    wrapFoo(SolidAngleQT)
 
     ## Base SI units
     wrapFoo(Second)

--- a/tests/tunchained.nim
+++ b/tests/tunchained.nim
@@ -621,7 +621,7 @@ suite "Unchained - practical examples turned tests":
     let t = 1.s
     let argument = ω * t + φ
     check typeof(argument) is Radian
-    check typeof(ω) is Second⁻¹•Radian
+    check typeof(ω) is Radian•Second⁻¹
     check typeof(A * cos(argument)) is CentiMeter
     check A * cos(argument) =~= -8.62319.cm
 


### PR DESCRIPTION
Adds each quantity as a `concept` so that they can be used to match types in procedure arguments:

```nim
proc force[M: Mass; A: Acceleration](m: M, a: A): Force = m * a
```
(or combine with explicit return type and a `.to(Foo)` call to get a specific type back.

edit: 
*Important note*: Using implicit generics involving these quantity concepts **is not supported**, because due to some limitation we can't extract the underlying type from these generics in the common use cases. Might be a simple upstream bugfix away though.

edit 2: ended up adding a bunch more things, a few possibly breaking (for certain use cases some things behave differently now).

Full changelog:

```
* v0.3.0
- concepts for each quantity to match different units of same quantity
  in procedure calls!
- ~<~ for CT units now sorts positive powers before negative, this can
  be a *breaking* change
- in `.` define the resulting type based on what's given, not
  simplified, this can be a *breaking* change
- add ~toDef~ to combine the usage of ~defUnit~ with ~to~ (this can be
  problematic, see docstring)
- clean up ~defUnit~ and also always generate the short name version
  of a given unit
- update README
```

The sorting of CT units (the separate units in a compound like `kg•m•...` has changed a bit. Previously the most important aspect was the precedence of the base unit itself. The power was used as a tie breaker in case the same unit appears twice. Now the power will also be used to adjust the sorting by giving higher precedence to any unit that has a positive power, if it's compared with a unit with negative power. The motivation was mainly (assuming the user sorted their units in that order naturally) that otherwise in a unit like `inch•s⁻¹` the order would be reversed to `s⁻¹•inch` as base units always had higher precedence than other units. This lead to a rather ugly unit notation that can cause users to trip.

Furthermore, we now generate always the long and short version when calling `defUnit` of the desired unit (previously only the version supplied by the user & the long one). In many cases the short and given one may be the same of course.

Next, comparisons of units finally now doesn't compare floats directly via `==` (as that is always problematic of course), but rather uses a custom `almostEqual` (copied from datamancer's existing proc). The epsilon used for comparison can be adjusted at CT by handing the parameter `-d:UnitCompareEpsilon=<integer>` where the integer is the negative power applied (default is 8, so `ε = 1e-8`).

The unit generated (if required) when using the dot operator now will also always generate the actual unit typed by the user instead of attempting a simplification. The gain for simplification (i.e reducing redundant powers of units) is not very big, but the possibility of accidentally changing the order of the units to something the user does not expect (due to something like the aforementioned change to `<`) is too big.

Finally, this also adds a `toDef` macro, which is essentially a local `defUnit` + `to` call for the use case when the unit is to be converted to a unit that isn't defined yet. It doesn't replace `to`, because in some use cases the compiler doesn't understand that a unit has been defined in the scope (because the macro call is written by the user via `defUnit`, but the macro hasn't been evaluated yet), thus redefining the unit. That can cause confusing errors with "got type X, needs type X = Alias".