### PR TITLE
Allow float size to change at CT via `-d:FloatBytes=4|8`

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,12 @@
+* v0.3.2
+- add ~FloatBytes~ ~intdefine~ variable, which allows to change the
+  underlying float type used at CT using ~-d:FloatBytes=4~.
+  Note: it might be advisable to also change the precision used to
+  compare two units using ~-d:UnitCompareEpsilon=~ and setting it to
+  some smaller value. Default is 8 corresponding to an epsilon of
+  ~1e-8~.
+  Further, using ~float32~ can be problematic if used in combination
+  with very low / very high SI prefixes due to the lower precision available.
 * v0.3.1
 - add new SI prefixes defined in November 2022:
   https://www.bipm.org/documents/20126/77765681/Resolutions-2022.pdf/281f3160-fc56-3e63-dbf7-77b76500990f

--- a/src/unchained/core_types.nim
+++ b/src/unchained/core_types.nim
@@ -3,8 +3,19 @@
 ## of them.
 import std / tables
 
+const FloatBytes* {.intdefine.} = 8
+
+when FloatBytes == 8:
+  type
+    FloatType* = float
+elif FloatBytes == 4:
+  type
+    FloatType* = float32
+else:
+  {.error: "Unsupported size for the underlying float type: " & $FloatBytes & " bytes.".}
+
 type
-  Unit* = distinct float
+  Unit* = distinct FloatType
 
   Quantity* = distinct Unit
   CompoundQuantity* = distinct Quantity
@@ -121,7 +132,7 @@ const SiShortPrefixStrTable* = block:
 proc `$`*(prefix: SiPrefix): string =
   result = SiPrefixTable[prefix]
 
-proc toFactor*(prefix: SiPrefix): float =
+proc toFactor*(prefix: SiPrefix): FloatType =
   ## note: can't compute value reasonably, due to hecto, centi, deci and deca
   case prefix
   of siQuecto:   result = 1e-30

--- a/src/unchained/ct_unit_types.nim
+++ b/src/unchained/ct_unit_types.nim
@@ -29,13 +29,13 @@ type
     unit*: DefinedUnit ## The actual underlying unit
     prefix*: SiPrefix # possibly differentiating prefix
     power*: int
-    value*: float
+    value*: FloatType
 
   UnitProduct* = object # a product of multiple (possibly compound) units
-    value*: float # value of this unit poduct
+    value*: FloatType # value of this unit poduct
     units*: seq[UnitInstance]
     init*: bool
-    #siPrefix*: float # as a pure float value
+    #siPrefix*: FloatType # as a pure float value
   UnitTable* = ref object
     # quantity stores the *base unit* referring to a quantity (the key)
     quantity*: Table[string, int]
@@ -89,7 +89,7 @@ proc newUnitInstance*(name: string,
                       u: DefinedUnit,
                       power: int,
                       prefix: SiPrefix,
-                      value: float = 1.0): UnitInstance =
+                      value: FloatType = 1.0): UnitInstance =
   result = UnitInstance(name: name,
                         unit: u,
                         power: power,

--- a/src/unchained/define_units.nim
+++ b/src/unchained/define_units.nim
@@ -123,7 +123,7 @@ proc toNimType*(x: UnitProduct, short = false): NimNode =
   let name = x.toNimTypeStr(short)
   result = if name.len == 0: ident("UnitLess") else: ident(name)
 
-proc toBaseTypeScale*(u: UnitInstance): float =
+proc toBaseTypeScale*(u: UnitInstance): FloatType =
   result = u.prefix.toFactor()
   result *= u.value
   ## XXX: multiply the `conversion` factor possibly if unit is not a base unit
@@ -134,7 +134,7 @@ proc toBaseTypeScale*(u: UnitInstance): float =
     result *= u.unit.conversion.value
   # divide out any possible base prefixes (e.g. for kilo gram)
   result /= u.unit.basePrefix.toFactor()
-  result = pow(result, u.power.float)
+  result = pow(result, u.power.FloatType)
 
 #[
 Overview of simplification procedures:
@@ -160,7 +160,7 @@ Probably `toBaseType` and `flatten` could be a single procedure as well.
 
 ## TODO: better distinguish between converting to base SI prefixes and
 ## converting non SI units to SI?
-proc toBaseTypeScale*(x: UnitProduct): float =
+proc toBaseTypeScale*(x: UnitProduct): FloatType =
   ## returns the scale required to turn `x` to its base type, i.e.
   ## turn all units that are not already to its base form. This
   ## includes converting non base prefix units to their base prefixes
@@ -199,7 +199,7 @@ proc toBaseType*(u: UnitInstance, needConversion: bool): UnitProduct =
         mbu.power *= u.power
         result.units.add mbu
       # now add possible further prefixes / powers of the input
-      result.value *= pow(u.prefix.toFactor(), u.power.float) # XXX: * u.value ? we don't use `value` atm
+      result.value *= pow(u.prefix.toFactor(), u.power.FloatType) # XXX: * u.value ? we don't use `value` atm
 
 proc toBaseType*(x: UnitProduct, needConversion: bool): UnitProduct =
   ## converts `x` to a unit representing the base type.
@@ -255,7 +255,7 @@ proc flatten*(units: UnitProduct, needConversion = true,
        noFlattenIdentity or
        noFlattenDerived:
       #var mu = unitInst
-      #factor *= pow(prefix.toFactor(), power.float)
+      #factor *= pow(prefix.toFactor(), power.FloatType)
       #mu.prefix = mu.unit.basePrefix
       result.add unitInst
     else:
@@ -272,7 +272,7 @@ proc flatten*(units: UnitProduct, needConversion = true,
         ## concept `SomeUnit`? No! If `Meter•Second⁻¹` is demanded we need that and
         ## not allow `CentiMeter•Second⁻¹`?
         # conversion factor is SI prefix to the unit's power
-        factor *= pow(prefix.toFactor, power.float)
+        factor *= pow(prefix.toFactor, power.FloatType)
         for b in unit.quantity.baseSeq:
           # convert given `QuantityPower` to a base unit
           var u = b.toUnitInstance()
@@ -433,7 +433,7 @@ proc parseConversion(n: NimNode): UnitProduct = ## DefinedUnitValue !
   let dotEx = n[0]
   result = parseDefinedUnit(dotEx[1].strVal)
   case dotEx[0].kind
-  of nnkIntLit: result.value = float(dotEx[0].intVal)
+  of nnkIntLit: result.value = FloatType(dotEx[0].intVal)
   of nnkFloatLit: result.value = dotEx[0].floatVal
   else: error("Invalid node for unit conversion definition " & $dotEx.repr & ".")
 

--- a/src/unchained/macro_utils.nim
+++ b/src/unchained/macro_utils.nim
@@ -78,6 +78,7 @@ proc getUnitTypeImpl*(n: NimNode): NimNode =
   of ntyDistinct: result = n.resolveTypeFromDistinct()
   of ntyTypeDesc: result = n.resolveTypeFromTypeDesc()
   of ntyGenericInst: result = n.resolveTypeFromGenericInst()
+  of ntyFloat32, ntyFloat64, ntyFloat: result = n
   of ntyUserTypeClass:
     ## NOTE: Attempting to resolve a type from such an implicit generic doesn't
     ## work properly. See tests/tResolveImplicitQuantity.nim

--- a/src/unchained/parse_units.nim
+++ b/src/unchained/parse_units.nim
@@ -188,6 +188,8 @@ proc tryLookupUnitType*(tab: UnitTable, n: NimNode): Option[UnitProduct] =
       result = some(tab.getUserDefined(nStr))
     elif nStr in tab:
       result = some(tab[nStr].toUnitInstance(assignPrefix = false).toUnitProduct())
+    elif nStr in ["FloatType", "float32", "float", "float64", "int", "int64", "UnitLess"]:
+      result = some(initUnitProduct())
 
   case n.kind
   of nnkIdent:
@@ -202,7 +204,7 @@ proc tryLookupUnitType*(tab: UnitTable, n: NimNode): Option[UnitProduct] =
     of nnkDistinctTy: nStr = nTyp[1].strVal
     of nnkSym: nStr = nTyp.strVal
     else: error("Invalid node for type : " & nTyp.repr)
-    if nStr in ["float", "float64", "int", "int64", "UnitLess"]:
+    if nStr in ["FloatType", "float32", "float", "float64", "int", "int64", "UnitLess"]:
       result = some(initUnitProduct())
     else:
       result = fromTab(tab, nStr)

--- a/src/unchained/si_units.nim
+++ b/src/unchained/si_units.nim
@@ -240,7 +240,7 @@ generateSiPrefixedUnits:
 
 ## Converters to help make Radian and Steradian more convenient. Will be
 ## generated in the future from the `declareUnit` macro.
-converter toRawFloat*(x: Radian): float = x.float
-converter toRawFloat*(x: Steradian): float = x.float
-converter toRadian*(x: float): Radian = x.Radian
-converter toSteradian*(x: float): Steradian = x.Steradian
+converter toRawFloat*(x: Radian): FloatType = x.FloatType
+converter toRawFloat*(x: Steradian): FloatType = x.FloatType
+converter toRadian*(x: FloatType): Radian = x.Radian
+converter toSteradian*(x: FloatType): Steradian = x.Steradian

--- a/src/unchained/utils.nim
+++ b/src/unchained/utils.nim
@@ -1,4 +1,5 @@
 import std / [macros]
+from core_types import FloatType
 
 macro `^`*(x: typed, num: static int): untyped =
   ## general purpose power using `^` for integers, which works for any
@@ -12,7 +13,7 @@ macro `^`*(x: typed, num: static int): untyped =
   elif num == 1:
     result = x
   elif num == -1:
-    ## Assume that the type supports addition by a float!
+    ## Assume that the type supports addition by a FloatType!
     result = quote do:
       1.0 / `x`
   else:
@@ -30,7 +31,7 @@ macro `^`*(x: typed, num: static int): untyped =
 
     # invert if num is negative
     if num < -1:
-      ## Assume that the type supports addition by a float!
+      ## Assume that the type supports addition by a FloatType!
       result = quote do:
         1.0 / (`result`)
 
@@ -38,7 +39,7 @@ macro `^`*(x: typed, num: static int): untyped =
 ## Number of digits to use as epsilon for unit comparison in `almostEqual`
 const UnitCompareEpsilon {.intdefine.} = 8
 import std / fenv
-proc almostEqual*(a, b: float, epsilon = 10^(-UnitCompareEpsilon)): bool =
+proc almostEqual*(a, b: FloatType, epsilon = 10^(-UnitCompareEpsilon)): bool =
   ## Comparison of two floats, taken from `datamancer` implementation. Only used
   ## internally to compare two units.
   # taken from
@@ -49,10 +50,10 @@ proc almostEqual*(a, b: float, epsilon = 10^(-UnitCompareEpsilon)): bool =
     diff = abs(a - b)
   if a == b: # shortcut, handles infinities
     result = true
-  elif a == 0 or b == 0 or (absA + absB) < minimumPositiveValue(float64):
+  elif a == 0 or b == 0 or (absA + absB) < minimumPositiveValue(FloatType):
     # a or b is zero or both are extremely close to it
     # relative error is less meaningful here
-    result = diff < (epsilon * minimumPositiveValue(float64))
+    result = diff < (epsilon * minimumPositiveValue(FloatType))
   else:
     # use relative error
-    result = diff / min(absA + absB, maximumPositiveValue(float64)) < epsilon
+    result = diff / min(absA + absB, maximumPositiveValue(FloatType)) < epsilon

--- a/unchained.nimble
+++ b/unchained.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.1"
+version       = "0.3.2"
 author        = "Vindaar"
 description   = "Fully type safe, compile time only units library"
 license       = "MIT"


### PR DESCRIPTION
Adds the option to change the float size used in bytes. 4 and 8 bytes supported. Fixes #35.

```
* v0.3.2
- add ~FloatBytes~ ~intdefine~ variable, which allows to change the
  underlying float type used at CT using ~-d:FloatBytes=4~.
  Note: it might be advisable to also change the precision used to
  compare two units using ~-d:UnitCompareEpsilon=~ and setting it to
  some smaller value. Default is 8 corresponding to an epsilon of
  ~1e-8~.
  Further, using ~float32~ can be problematic if used in combination
  with very low / very high SI prefixes due to the lower precision available.
```