### PR TITLE
Fix `min` issue due to emitting `short` unit names

### DIFF
--- a/src/unchained/define_units.nim
+++ b/src/unchained/define_units.nim
@@ -95,7 +95,15 @@ proc toNimTypeStr*(tab: var UnitTable, x: UnitProduct, short = false,
   # return early if no units in x or if we know the unit's string repr
   if x.units.len == 0: return "UnitLess"
   elif short and x in tab.unitNames: return tab.unitNames[x]
-  elif not short and x in tab.unitNamesLong: return tab.unitNamesLong[x]
+  elif not short and x in tab.unitNamesLong:
+    ## XXX: I have no idea what the hell is going on here. Somehow our table
+    ## gets corrupted sometimes. The element we retrieve is suddenly a UnitProduct
+    ## with a single element. If that is found, delete it and recreate the string.
+    let name = tab.unitNamesLong[x]
+    if name.strip.len == 0:
+      tab.unitNamesLong.del(x)
+    else:
+      return tab.unitNamesLong[x]
 
   result = newStringOfCap(100)
   let xSorted = x.units.sorted

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -426,14 +426,14 @@ macro to*[T: SomeUnit; U: SomeUnit](x: T; to: typedesc[U]): U =
   let xCT = x.parseDefinedUnit()
   let yCT = to.parseDefinedUnit()
   if xCT == yCT:
-    let resType = yCT.toNimType(short = true)
+    let resType = yCT.toNimType()
     result = quote do:
       `resType`(`x`)
   elif commonQuantity(xCT, yCT):
     # perform conversion
     ## thus determine scaling factor due to different SI prefixes
     let scale = xCT.toBaseTypeScale() / yCT.toBaseTypeScale()
-    let resType = yCT.toNimType(short = true)
+    let resType = yCT.toNimType()
     result = quote do:
       `resType`(`x`.FloatType * `scale`)
   else:


### PR DESCRIPTION
We now emit long names again for the units in `to`. This is not an issue anymore, as we fully alias all short and long units that are constructed and take care to generate the short string name by default.

Also work around a weird bug as mentioned in the commit message / comment in code.