### PR TITLE
emit short and long versions of user given types

### DIFF
--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -163,10 +163,17 @@ macro defUnit*(arg: untyped, toExport: bool = false): untyped =
 
   result = newStmtList()
   if resType.strVal != "UnitLess":
+    let argShort = argCT.toNimType(short = true)
+    let argLong = argCT.toNimType(short = false)
     result.add emitType(baseType,      distinctQuant, toExport)
     result.add emitType(baseTypeShort, baseType,      toExport)
     result.add emitType(resType,       baseType,      toExport)
     result.add emitType(resTypeShort,  baseType,      toExport)
+    # emit short version, but sorted by unit order
+    result.add emitType(argShort,      baseType,      toExport)
+    # same as long
+    result.add emitType(argLong,       baseType,      toExport)
+    # emit as user intended
     result.add emitType(arg,           baseType,      toExport)
   else:
     result.add emitType(arg,          resType, toExport)

--- a/tests/tunchained.nim
+++ b/tests/tunchained.nim
@@ -670,6 +670,11 @@ suite "Unchained - isAUnit concept checking":
     check not isAUnit(string)
     check not isAUnit(seq[string])
 
+    defUnit(m•J)
+    check isAUnit(m•J) # as user intended
+    check isAUnit(Joule•Meter) # long form of correct order
+    check isAUnit(J•m) # short form of correct order
+
 suite "Unchained - syntax in accented quotes":
   test "Basic units in accented quotes":
     check 5.`Meter*Second^-1` == 5.m•s⁻¹
@@ -987,6 +992,14 @@ suite "Unchained - Bug issues":
       let fooImperial = FooImperial(time: 5.min, length: 42.ft)
       ## the following should compile without an error
       let fooInternational = fooImperial.convertUnitsPairs(FooInternational)
+
+  test "Confusion of long and short units":
+    # this needs to generate not only `ft²•ft⁻³`, but also the long form
+    # as we now emit `Foot²•Foot⁻³` in some cases. So the type must be known.
+    defUnit(ft²•ft⁻³)
+    let x = 1.m⁻¹
+    check x.to(ft²•ft⁻³) == 0.3048.ft⁻¹
+    check x.to(ft²•ft⁻³) == 0.3048.ft²•ft⁻³
 
 suite "Utils":
   test "Power w/ static integer exponents for floats":


### PR DESCRIPTION
Works around the following:

```nim
    defUnit(ft²•ft⁻³)
    let x = 1.m⁻¹
    check x.to(ft²•ft⁻³) == 0.3048.ft⁻¹
    check x.to(ft²•ft⁻³) == 0.3048.ft²•ft⁻³
```
now producing problems as we emit the long form of user given types later. Those were not defined, because we only define long versions of the *reduced* version, i.e. `Foot⁻¹`.