### PR TITLE
Torr, fix parsing regression and cligen helper submodule

### DIFF
--- a/README.org
+++ b/README.org
@@ -211,4 +211,89 @@ errors due to unit mismatches by using this lib! Tada!
 
 *Hint*: The unit =Chain= does not exist in this library...
 
+** Units and ~cligen~
 
+~cligen~ is arguably the most powerful and at the same time convenient
+to use command line argument parser in Nim land (and likely across
+languages...; plus a lot of other things!).
+
+For that reason it is a common desire to combine ~Unchained~ units as
+an command line argument to a program that uses ~cligen~ to parse the
+arguments. Thanks to ~cligen's~ extensive options to expand its
+features, we now provide a simple submodule you can import in order to
+support ~Unchained~ units in your program. Here's a short example
+useful for the runners among you, a simple script to convert a given
+speed (in mph, km/h or m/s) to a time per minute / per mile / 5K / 10K
+/ ... distance or vice versa:
+#+begin_src nim :tangle examples/speed_tool.nim
+import unchained, math, strutils
+defUnit(mi•h⁻¹)
+defUnit(km•h⁻¹)
+defUnit(m•s⁻¹)
+proc timeStr[T: Time](t: T): string =
+  let (h, mr) = splitDecimal(t.to(Hour).float)
+  let (m, s)  = splitDecimal(mr.Hour.to(Minute).float)
+  result =
+    align(pretty(h.Hour, 0, true, ffDecimal), 6, ' ') &
+    " " & align(pretty(m.Minute, 0, true, ffDecimal), 8, ' ') &
+    " " & align(pretty(s.Minute.to(Second), 0, true, ffDecimal), 6, ' ')
+template print(d, x) = echo "$#: $#" % [alignLeft(d, 9), align(x, 10)]
+proc echoTimes[V: Velocity](v: V) =
+  print("1K",       timeStr 1.0 / (v / 1.km))
+  print("1 mile",   timeStr 1.0 / (v / 1.Mile))
+  print("5K",       timeStr 1.0 / (v / 5.km))
+  print("10K",      timeStr 1.0 / (v / 10.km))
+  print("Half",     timeStr 1.0 / (v / (42.195.km / 2.0)))
+  print("Marathon", timeStr 1.0 / (v / 42.195.km))
+  print("50K",      timeStr 1.0 / (v / 50.km))
+  print("100K",     timeStr 1.0 / (v / 100.km))   # maybe a bit aspirational at the same pace, huh?
+  print("100 mile", timeStr 1.0 / (v / 100.Mile)) # let's hope it's not Leadville
+proc mph(v: mi•h⁻¹) = echoTimes(v)
+proc kmh(v: km•h⁻¹) = echoTimes(v)
+proc mps(v:  m•s⁻¹) = echoTimes(v)
+proc speed(d: km, hour = 0.0.h, min = 0.0.min, sec = 0.0.s) =
+  let t = hour + min + sec
+  print("km/h", pretty((d / t).to(km•h⁻¹), 2, true))
+  print("mph",  pretty((d / t).to(mi•h⁻¹), 2, true))
+  print("m/s",  pretty((d / t).to( m•s⁻¹), 2, true))
+when isMainModule:
+  import unchained / cligenParseUnits # just import this and then you can use `unchained` units as parameters!
+  import cligen
+  dispatchMulti([mph], [kmh], [mps], [speed])
+#+end_src
+
+#+begin_src sh :results drawer
+nim c examples/speed_tool
+examples/speed_tool mph -v 7.0 # without unit, assumed is m•h⁻¹
+echo "----------------------------------------"
+examples/speed_tool kmh -v 12.5.km•h⁻¹ # with explicit unit
+echo "----------------------------------------"
+examples/speed_tool speed -d 11.24.km --min 58 --sec 4
+#+end_src
+
+#+RESULTS:
+:results:
+1K       :  0 h  5 min 20 s
+1 mile   :  0 h  8 min 34 s
+5K       :  0 h 26 min 38 s
+10K      :  0 h 53 min 16 s
+Half     :  1 h 52 min 22 s
+Marathon :  3 h 44 min 44 s
+50K      :  4 h 26 min 18 s
+100K     :  8 h 52 min 36 s
+100 mile : 14 h 17 min  9 s
+----------------------------------------
+1K       :  0 h  4 min 48 s
+1 mile   :  0 h  7 min 43 s
+5K       :  0 h 24 min  0 s
+10K      :  0 h 48 min  0 s
+Half     :  1 h 41 min 16 s
+Marathon :  3 h 22 min 32 s
+50K      :  4 h  0 min  0 s
+100K     :  8 h  0 min  0 s
+100 mile : 12 h 52 min 29 s
+----------------------------------------
+km/h     : 12 km•h⁻¹
+mph      : 7.2 mi•h⁻¹
+m/s      : 3.2 m•s⁻¹
+:end:

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,7 @@
+* v0.3.6
+- add ~Torr~ as a unit of pressure
+- fixes a regression when parsing units with unicode runes (μ)
+- add submodule to help with parsing units in ~cligen~ program arguments    
 * v0.3.5
 - fix parsing units possibly returning uninitialized ~UnitProduct~ (in
   particular when dealing with type aliases of ~UnitLess~)

--- a/src/unchained/cligenParseUnits.nim
+++ b/src/unchained/cligenParseUnits.nim
@@ -1,0 +1,22 @@
+import cligen/argcvt
+import unchained
+proc argParse*[T: SomeUnit](dst: var T, dfl: T,
+                           a: var ArgcvtParams): bool =
+  try:
+    let aStr = a.val
+    var tmp: T
+    let unitName = unitOf(tmp)
+    if aStr.endsWith(unitName):
+      proc removeSuffix(s, p: string): string =
+        result = s
+        result.removeSuffix(p)
+      dst = aStr.removeSuffix(unitName).strip.parseFloat.T
+    else:
+      dst = aStr.strip.parseFloat.T
+    result = true
+  except:
+    result = false
+
+proc argHelp*[T: SomeUnit](dfl: T; a: var ArgcvtParams): seq[string] =
+  var tmp: T
+  result = @[ a.argKeys, unitOf(tmp), $dfl ]

--- a/src/unchained/cligenParseUnits.nim
+++ b/src/unchained/cligenParseUnits.nim
@@ -1,3 +1,4 @@
+import std / strutils
 import cligen/argcvt
 import unchained
 proc argParse*[T: SomeUnit](dst: var T, dfl: T,
@@ -5,12 +6,12 @@ proc argParse*[T: SomeUnit](dst: var T, dfl: T,
   try:
     let aStr = a.val
     var tmp: T
-    let unitName = unitOf(tmp)
+    let unitName = "." & unitOf(tmp)
     if aStr.endsWith(unitName):
       proc removeSuffix(s, p: string): string =
         result = s
         result.removeSuffix(p)
-      dst = aStr.removeSuffix(unitName).strip.parseFloat.T
+      dst = aStr.removeSuffix(unitName).parseFloat.T
     else:
       dst = aStr.strip.parseFloat.T
     result = true

--- a/src/unchained/ct_unit_types.nim
+++ b/src/unchained/ct_unit_types.nim
@@ -28,7 +28,8 @@ type
     name*: string # the part of the nim node that was parsed into this
     unit*: DefinedUnit ## The actual underlying unit
     prefix*: SiPrefix # possibly differentiating prefix
-    power*: int
+    power*: int ## XXX: we could make the power a `Rational` and that way support `sqrt` and things in a
+                ## ~ reasonable way without having to rely on float hacks.
     value*: FloatType
 
   UnitProduct* = object # a product of multiple (possibly compound) units

--- a/src/unchained/parse_units.nim
+++ b/src/unchained/parse_units.nim
@@ -5,7 +5,7 @@ import core_types, ct_unit_types, macro_utils
 
 from std / tables import getOrDefault, `[]`
 
-proc parseSiPrefixShort(c: char): SiPrefix =
+proc parseSiPrefixShort(c: Rune): SiPrefix =
   ## For the case of short SI prefixes (i.e. single character) return it
   result = SiShortPrefixStrTable.getOrDefault($c, siIdentity) # initialize with identity, in case none match
 
@@ -32,7 +32,7 @@ proc parsePrefixAndUnit(tab: UnitTable, x: string, start, stop: int):
   ## returns both the prefix as well as the unit itself.
   # NOTE: can we avoid the string slice copies? :/
   result.prefix = siIdentity
-  case stop - start
+  case x[start ..< stop].runeLen # stop - start
   of 0: # invalid
     doAssert false
   of 1: # short unit without SI prefix
@@ -48,7 +48,7 @@ proc parsePrefixAndUnit(tab: UnitTable, x: string, start, stop: int):
       result.unit = unitOpt.get
     else:
       # first char must be short prefix & second a short unit, e.g. `mN`
-      result.prefix = parseSiPrefixShort(x[start])
+      result.prefix = parseSiPrefixShort(x.runeAt(start))
       result.unit = tab.getShort($x[stop-1])
   else:
     # try any unit
@@ -60,7 +60,7 @@ proc parsePrefixAndUnit(tab: UnitTable, x: string, start, stop: int):
       unitOpt = tab.tryLookupUnit(x[start+1 ..< stop])
       if unitOpt.isSome:
         result.unit = unitOpt.get
-        result.prefix = parseSiPrefixShort(x[start]) # in this case prefix must be short
+        result.prefix = parseSiPrefixShort(x.runeAt(start)) # in this case prefix must be short
       else:
         # must be long + long, e.g. `KiloGram`
         # must have prefix, thus parse until upper, that defines prefix & unit

--- a/src/unchained/si_units.nim
+++ b/src/unchained/si_units.nim
@@ -129,6 +129,11 @@ declareUnits:
       quantity: MagneticFieldStrength
       conversion: 1e-4.T # non SI defined by having a conversion
 
+    Torr:
+      short: torr
+      quantity: Pressure
+      conversion: 133.322368421.Pa # 101325.0 / 760.0 <-> (1 atm / 760 Torr)
+
     # given that we have base units & derived base units defined, we can now just
     # dump everything together. Everything that is referenced before, can now be
     # used to define new units.

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -68,8 +68,9 @@ macro unitName(t: typed): untyped =
   let typ = t.parseDefinedUnit()
   result = newLit typ.pretty(short = false)
 
-proc prettyImpl*(s: FloatType, typStr: string, precision: int, short: bool): string =
-  result = s.formatFloat(precision = precision)
+proc prettyImpl*(s: FloatType, typStr: string, precision: int, short: bool,
+                 format: FloatFormatMode): string =
+  result = s.formatFloat(format = format, precision = precision)
   result.trimZeros()
   if not short:
     when not defined(noUnicode):
@@ -112,14 +113,14 @@ macro `$`*[T: SomeUnit](s: T): string =
   let typStr = s.parseDefinedUnit().toNimTypeStr(short = ShortFormat,
                                                  internal = false)
   result = quote do:
-    prettyImpl(`s`.FloatType, `typStr`, precision = -1, short = ShortFormat)
+    prettyImpl(`s`.FloatType, `typStr`, precision = -1, short = ShortFormat, format = ffDefault)
 
-macro pretty*[T: SomeUnit](s: T, precision: int, short: bool): untyped =
+macro pretty*[T: SomeUnit](s: T, precision: int, short: bool, format = ffDefault): untyped =
   ## Equivalent to `$`, but allows to change precision and switch to long format.
   let typStr = s.parseDefinedUnit().toNimTypeStr(short = ShortFormat,
                                                  internal = false)
   result = quote do:
-    prettyImpl(`s`.FloatType, `typStr`, precision = `precision`, short = `short`)
+    prettyImpl(`s`.FloatType, `typStr`, precision = `precision`, short = `short`, format = `format`)
 
 macro defUnit*(arg: untyped, toExport: bool = false): untyped =
   ## Defines the given unit `arg` the scope. If `toExport` is `true` and the call happens


### PR DESCRIPTION
Full changelog:

See the new README section at the bottom for an example of the `cligen` helper module.
```
* v0.3.6
  - add ~Torr~ as a unit of pressure
  - fixes a regression when parsing units with unicode runes (μ)
  - add submodule to help with parsing units in ~cligen~ program arguments
```