### PR TITLE
improve type extraction for aliases

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,9 @@
+* v0.3.7
+- add the unit ~Erg~ commonly used in astronomy
+- improve type extraction for element access from sequences with types
+  & in particular sequences whose types have been defined by a ~mapIt~
+  call
+- fix extra colon in unit parsing (PR #41)
 * v0.3.6
 - add ~Torr~ as a unit of pressure
 - fixes a regression when parsing units with unicode runes (μ)

--- a/src/unchained/macro_utils.nim
+++ b/src/unchained/macro_utils.nim
@@ -46,8 +46,11 @@ proc resolveTypeFromAlias(n: NimNode): NimNode =
   of nnkSym:
     let typ = n.getImpl
     doAssert typ.kind == nnkTypeDef, " no, was " & $typ.treerepr
-    if typ[2].typeKind == ntyAlias:
+    case typ[2].typeKind
+    of ntyAlias:
       result = typ[2].resolveTypeFromAlias()
+    of ntyDistinct: # can be result of a `mapIt` call (i.e. type via `typeof(block...)`
+      result = typ[2].getTypeInst.getUnitTypeImpl()
     else:
       case typ[2].kind
       of nnkInfix: # this is a type class A = B | C | D, ... return input

--- a/src/unchained/macro_utils.nim
+++ b/src/unchained/macro_utils.nim
@@ -40,6 +40,7 @@ iterator getPow10Digits*(x: int): int =
   for el in digits.reversed:
     yield el
 
+proc getUnitTypeImpl*(n: NimNode): NimNode
 proc resolveTypeFromAlias(n: NimNode): NimNode =
   case n.kind
   of nnkSym:
@@ -54,9 +55,7 @@ proc resolveTypeFromAlias(n: NimNode): NimNode =
       else:
         result = typ[2]
   else:
-    let typ = n.getTypeImpl
-    doAssert typ.kind == nnkDistinctTy, " no, was " & $typ.treerepr
-    result = typ[0]
+    result = n.getTypeInst.getUnitTypeImpl()
 
 proc resolveTypeFromDistinct(n: NimNode): NimNode =
   let typ = n.getImpl

--- a/src/unchained/si_units.nim
+++ b/src/unchained/si_units.nim
@@ -134,6 +134,11 @@ declareUnits:
       quantity: Pressure
       conversion: 133.322368421.Pa # 101325.0 / 760.0 <-> (1 atm / 760 Torr)
 
+    Erg:
+      short: erg
+      quantity: Energy
+      conversion: 1e-7.J
+
     # given that we have base units & derived base units defined, we can now just
     # dump everything together. Everything that is referenced before, can now be
     # used to define new units.


### PR DESCRIPTION
Slight improvement to extraction of type information for aliases when looking at a typed bracket expression (e.g. `X[idx]` of fields of `unchained` types).

- [x] Add test case based on our example that produces it.

Update:
- further improved the type extraction also for slightly other cases of using `mapIt` for type conversion.
- add `Erg` as a unit