### PR TITLE
Some more astronomical units & arc units

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,19 @@
+* v0.3.8
+- add some more astronomical units:
+  - ~AstronomicalUnit~, ~AU~
+  - ~LightYear~, ~ly~
+  - ~Parsec~, ~parsec~ (not ~pc~ due to pico coulomb)
+- add degree related units:
+  - ~ArcMinute~, ~arcmin~
+  - ~ArcSecond~, ~arcsec~
+- *BREAKING*: Change definition of 1 year from 365 days to 365.25 days
+  (1 Julian year), matching definition of a light year. Otherwise they
+  would disagree if computed "by hand" using our units.  More precise,
+  but of course highly dependent on your calendar / definitions
+  -> For these time units it would probably be best to have different sets of units
+  / unit systems, i.e. GregorianYear etc.
+  Anyone dealing with time units should be aware that these things are
+  tricky and best be dealt with _given their specific application_!
 * v0.3.7
 - add the unit ~Erg~ commonly used in astronomy
 - improve type extraction for element access from sequences with types

--- a/src/unchained/si_units.nim
+++ b/src/unchained/si_units.nim
@@ -199,7 +199,7 @@ declareUnits:
     Year:
       short: yr
       quantity: Time
-      conversion: 31536000.s # 365.0 * 86400.0, could also use ~365.25...
+      conversion: 31557600.s # 365.25 * 86400.0 (Julian year) (to match definition of lightyear)
 
     # Imperial
     Pound:

--- a/src/unchained/si_units.nim
+++ b/src/unchained/si_units.nim
@@ -139,6 +139,21 @@ declareUnits:
       quantity: Energy
       conversion: 1e-7.J
 
+    AstronomicalUnit:
+      short: AU
+      quantity: Length
+      conversion: 149_597_870_700.0.m # by definition since 2012
+
+    LightYear:
+      short: ly
+      quantity: Length
+      conversion: 9_460_730_472_580_800.0.m # 365.25 * 86400 * c_0
+
+    Parsec:
+      short: parsec
+      quantity: Length
+      conversion: 30856775814913673.0.m # 1 AU * 180° * 60 * 60 / π
+
     # given that we have base units & derived base units defined, we can now just
     # dump everything together. Everything that is referenced before, can now be
     # used to define new units.
@@ -160,6 +175,15 @@ declareUnits:
       short: °
       quantity: Angle
       conversion: 0.0174532925199.rad # PI / 180.0
+    ArcMinute:
+      short: arcmin
+      quantity: Angle
+      conversion: 0.000290888.rad # 1.° / 60.0 in Radian
+    ArcSecond:
+      short: arcsec
+      quantity: Angle
+      conversion: 0.0000048481368111.rad # 1.° / (60 * 60) in Radian
+
     Minute:
       short: min
       quantity: Time


### PR DESCRIPTION
Note the change to the definition of 1 year!

```
* v0.3.8
- add some more astronomical units:
  - ~AstronomicalUnit~, ~AU~
  - ~LightYear~, ~ly~
  - ~Parsec~, ~parsec~ (not ~pc~ due to pico coulomb)
- add degree related units:
  - ~ArcMinute~, ~arcmin~
  - ~ArcSecond~, ~arcsec~
- *BREAKING*: Change definition of 1 year from 365 days to 365.25 days
  (1 Julian year), matching definition of a light year. Otherwise they
  would disagree if computed "by hand" using our units.  More precise,
  but of course highly dependent on your calendar / definitions
  -> For these time units it would probably be best to have different sets of units
  / unit systems, i.e. GregorianYear etc.
  Anyone dealing with time units should be aware that these things are
  tricky and best be dealt with _given their specific application_!
```