### PR TITLE
skip postfix node when resolving distinct type from impl AST

### DIFF
--- a/src/unchained/macro_utils.nim
+++ b/src/unchained/macro_utils.nim
@@ -64,6 +64,7 @@ proc resolveTypeFromDistinct(n: NimNode): NimNode =
   let typ = n.getImpl
   doAssert typ.kind == nnkTypeDef
   result = typ[0]
+  if result.kind == nnkPostfix: result = result[1]
 
 proc resolveTypeFromTypeDesc(n: NimNode): NimNode =
   let typ = n.getType


### PR DESCRIPTION
`resolveTypeFromDistinct` calls `getImpl` on the distinct type which yields an `nkTypeDef` node of the original distinct type declaration, and returns the first child of the node, what would normally be the type name.

Normally when a type is exported its name in the AST becomes an `nkPostfix` node, however due to a [Nim bug](https://github.com/nim-lang/Nim/issues/22933) this node was not saved in typed AST and the first child was always the type symbol node. If the bug in Nim is fixed, `resolveTypeFromDistinct` has to skip the postfix node here.