### PR TITLE
Add `Barn`, improved error messages

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,10 @@
+* v0.4.0
+- add unit of ~Barn~
+- BREAKING: rename short form of Gauss to ~gauss~. Single capital ~G~
+  is too brittle combined with Giga prefix
+- improve printed unit names in error messages
+- add hbar as a constant
+- add note about natural unit convention used      
 * v0.3.10
 - fix for ~nnkPostfix~ nodes in macro logic
 * v0.3.9

--- a/src/unchained/constants.nim
+++ b/src/unchained/constants.nim
@@ -20,4 +20,5 @@ const
   #K = 4 * π * N_A * r_e * r_e * m_e_c2 * (100.0^2)# [MeV mol⁻¹ cm²]
   k_B* = 1.380649e-23.Joule•Kelvin⁻¹
   hp* = 6.62607015e-34.Joule•Hertz⁻¹
+  hp_bar* = hp / (2 * π)
   G_Newton* = 6.6743e-11.N•m²•kg⁻²

--- a/src/unchained/define_units.nim
+++ b/src/unchained/define_units.nim
@@ -720,9 +720,11 @@ macro isAUnit*(x: typed): untyped =
   ## `getUnitTypeImpl` & making use of CT tables (possibly of objects?)
   let x = x.resolveAlias()
   case x.kind
-  of nnkSym, nnkDistinctTy:
+  of nnkSym, nnkDistinctTy, nnkPostfix:
     let typ = x
-    var xT = if typ.kind == nnkDistinctTy: typ[0] else: typ
+    var xT = if typ.kind == nnkDistinctTy: typ[0]
+             elif typ.kind == nnkPostfix: typ[1]
+             else: typ
     while xT.strVal notin quantityList():
       xT = xT.getTypeImpl
       case xT.kind

--- a/src/unchained/si_units.nim
+++ b/src/unchained/si_units.nim
@@ -184,6 +184,12 @@ declareUnits:
       quantity: Angle
       conversion: 0.0000048481368111.rad # 1.° / (60 * 60) in Radian
 
+    # Area commonly used for cross sections in atomic / particle physics
+    Barn:
+      short: barn # `b` is too ambiguous with prefixes
+      quantity: Area
+      conversion: 1e-28.m²
+
     Minute:
       short: min
       quantity: Time
@@ -271,6 +277,8 @@ generateSiPrefixedUnits:
   (sr, Steradian)
   (T, Tesla) exclude [f] # fT would be ambiguous with `ft` (foot)
   (Bq, Becquerel)
+  (gauss, Gauss)
+  (barn, Barn)
 
 ## Converters to help make Radian and Steradian more convenient. Will be
 ## generated in the future from the `declareUnit` macro.

--- a/src/unchained/si_units.nim
+++ b/src/unchained/si_units.nim
@@ -125,7 +125,7 @@ declareUnits:
 
     # Non SI units
     Gauss:
-      short: G
+      short: gauss
       quantity: MagneticFieldStrength
       conversion: 1e-4.T # non SI defined by having a conversion
 

--- a/src/unchained/si_units.nim
+++ b/src/unchained/si_units.nim
@@ -248,6 +248,9 @@ declareUnits:
   # definition of the conversions to natural units for all base units
   # takes place here, because at definition of the base units the `eV` unit
   # is not defined yet.
+  # Lorentz-Heaviside convention, c = ε_0 = hbar = k_B = 1, but explicitly
+  # no mass (electron or proton) is set to 1, nor do we swallow any factors
+  # of 4π!
   NaturalUnits:
     Gram: 1.7826627e-33.eV # relative to g and not kg!
     Meter: 1.9732705e-7.eV⁻¹

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -201,7 +201,7 @@ macro `==`*[T: SomeUnit; U: SomeUnit](x: T, y: U): bool =
     result = quote do:
       `almostEq`(`x`.FloatType * `xScale`, `y`.FloatType * `yScale`)
   else:
-    error("Different quantities cannot be compared! Quantity 1: " & (x.getTypeInst).repr & ", Quantity 2: " & (y.getTypeInst).repr)
+    error("Different quantities cannot be compared! Quantity 1: " & pretty(xCT) & ", Quantity 2: " & pretty(yCT))
 
 macro `<`*[T: SomeUnit|SomeNumber; U: SomeUnit|SomeNumber](x: T; y: U): untyped =
   var xCT = parseDefinedUnit(x)
@@ -217,7 +217,7 @@ macro `<`*[T: SomeUnit|SomeNumber; U: SomeUnit|SomeNumber](x: T; y: U): untyped 
     result = quote do:
       (`x`.FloatType * `xScale` < `y`.FloatType * `yScale`)
   else:
-    error("Different quantities cannot be compared! Quantity 1: " & (x.getTypeInst).repr & ", Quantity 2: " & (y.getTypeInst).repr)
+    error("Different quantities cannot be compared! Quantity 1: " & pretty(xCT) & ", Quantity 2: " & pretty(yCT))
 
 macro `<=`*[T: SomeUnit|SomeNumber; U: SomeUnit|SomeNumber](x: T; y: U): untyped =
   var xCT = parseDefinedUnit(x)
@@ -233,7 +233,7 @@ macro `<=`*[T: SomeUnit|SomeNumber; U: SomeUnit|SomeNumber](x: T; y: U): untyped
     result = quote do:
       (`x`.FloatType * `xScale` <= `y`.FloatType * `yScale`)
   else:
-    error("Different quantities cannot be compared! Quantity 1: " & (x.getTypeInst).repr & ", Quantity 2: " & (y.getTypeInst).repr)
+    error("Different quantities cannot be compared! Quantity 1: " & pretty(xCT) & ", Quantity 2: " & pretty(yCT))
 
 macro `+`*[T: SomeUnit|SomeNumber; U: SomeUnit|SomeNumber](x: T; y: U): untyped =
   var xCT = parseDefinedUnit(x)
@@ -262,7 +262,7 @@ macro `+`*[T: SomeUnit|SomeNumber; U: SomeUnit|SomeNumber](x: T; y: U): untyped 
       defUnit(`resType`)
       `resType`(`xr`.FloatType * `xScale` + `yr`.FloatType * `yScale`)
   else:
-    error("Different quantities cannot be added! Quantity 1: " & (x.getTypeInst).repr & ", Quantity 2: " & (y.getTypeInst).repr)
+    error("Different quantities cannot be added! Quantity 1: " & pretty(xCT) & ", Quantity 2: " & pretty(yCT))
 
 macro `-`*[T: SomeUnit|SomeNumber; U: SomeUnit|SomeNumber](x: T; y: U): untyped =
   var xCT = parseDefinedUnit(x)
@@ -293,7 +293,7 @@ macro `-`*[T: SomeUnit|SomeNumber; U: SomeUnit|SomeNumber](x: T; y: U): untyped 
       defUnit(`resType`)
       `resType`(`xr`.FloatType * `xScale` - `yr`.FloatType * `yScale`)
   else:
-    error("Different quantities cannot be subtracted! Quantity 1: " & (x.getTypeInst).repr & ", Quantity 2: " & (y.getTypeInst).repr)
+    error("Different quantities cannot be subtracted! Quantity 1: " & pretty(xCT) & ", Quantity 2: " & pretty(yCT))
 
 proc `-`*[T: SomeUnit](x: T): T = (-(x.FloatType)).T
 
@@ -445,7 +445,7 @@ macro to*[T: SomeUnit; U: SomeUnit](x: T; to: typedesc[U]): U =
     result = quote do:
       `resType`(`x`.FloatType * `scale`)
   else:
-    error("Cannot convert " & $T & " to " & $U & " as they represent different " &
+    error("Cannot convert " & pretty(xCT) & " to " & pretty(yCT) & " as they represent different " &
       "quantities!")
 
 macro toDef*[T: SomeUnit](x: T, to: untyped): untyped =


### PR DESCRIPTION
Some minor changes, with one breaking change. Renaming `G` for Gauss to `gauss`, due to potential problems with Giga SI prefix. 

The version bump to `v0.4.0` is mainly as this is the state used for the results in my thesis.

Full changelog:
```
* v0.4.0
- add unit of ~Barn~
- BREAKING: rename short form of Gauss to ~gauss~. Single capital ~G~
  is too brittle combined with Giga prefix
- improve printed unit names in error messages
- add hbar as a constant
- add note about natural unit convention used
```