### PR TITLE
Fix unit parsing including bad prefixes, closes #48

### DIFF
--- a/src/unchained/parse_units.nim
+++ b/src/unchained/parse_units.nim
@@ -50,6 +50,8 @@ proc parsePrefixAndUnit(tab: UnitTable, x: string, start, stop: int):
       # first char must be short prefix & second a short unit, e.g. `mN`
       result.prefix = parseSiPrefixShort(x.runeAt(start))
       result.unit = tab.getShort($x[stop-1])
+      if result.prefix == siIdentity:
+        error("The prefix `" & $x.runeAt(start) & "` of the unit `" & x & "` is not a valid prefix!")
   else:
     # try any unit
     var unitOpt = tab.tryLookupUnit(x[start ..< stop])
@@ -61,6 +63,8 @@ proc parsePrefixAndUnit(tab: UnitTable, x: string, start, stop: int):
       if unitOpt.isSome:
         result.unit = unitOpt.get
         result.prefix = parseSiPrefixShort(x.runeAt(start)) # in this case prefix must be short
+        if result.prefix == siIdentity:
+          error("The prefix `" & $x.runeAt(start) & "` of the unit `" & x & "` is not a valid prefix!")
       else:
         # must be long + long, e.g. `KiloGram`
         # must have prefix, thus parse until upper, that defines prefix & unit
@@ -70,6 +74,8 @@ proc parsePrefixAndUnit(tab: UnitTable, x: string, start, stop: int):
         # look up long prefix
         result.prefix = parseSiPrefixLong(x[start] & prefixStr)
         result.unit = tab.lookupUnit(x[start + prefixNum + 1 ..< stop])
+        if result.prefix == siIdentity:
+          error("The prefix `" & $x[start] & prefixStr & "` of the unit `" & x & "` is not a valid prefix!")
 
 template addUnit(): untyped {.dirty.} =
   ## Dirty template used in both parsing procedures (unicode & ascii)

--- a/tests/tunchained.nim
+++ b/tests/tunchained.nim
@@ -1162,6 +1162,18 @@ suite "Quantity concepts":
     else:
       check true
 
+  test "Verify invalid prefixes are not allowed":
+    ## Ref: issue #48
+    let val = 100.Foot
+    when compiles(val.toMeter()):
+      check false
+    when compiles(val.toKiloGram()):
+      check false
+    when compiles(val.foobarMeter()):
+      check false
+    when compiles(val.tMeter()):
+      check false
+
 suite "Unchained - math with typedescs to define units":
   test "Pure typedesc math defines units":
     block:
@@ -1224,6 +1236,8 @@ suite "Unchained - math with typedescs to define units":
     block:
       let x = 1.kg * 1.m^2 * s^(-1)
       check x == 1.kg•m²•s⁻¹
+
+
 
 #converter to_eV(x: GeV): eV =
 #  echo "toEv!"


### PR DESCRIPTION
Fixes the issue by raising a CT error in case the given prefix does not make any sense.