### PR TITLE
Improve `to` to use exact type as given by the user

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,32 +17,31 @@ on:
 
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        #branch: [version-1-2, version-1-4, devel]
-        branch: [version-1-6, devel]
-        target: [linux, macos, windows]
-        include:
-          - target: linux
-            builder: ubuntu-latest
-          - target: macos
-            builder: macos-latest
-          - target: windows
-            builder: windows-latest
-    name: '${{ matrix.target }} (${{ matrix.branch }})'
-    runs-on: ${{ matrix.builder }}
+        nim:
+          - '1.6.x'
+          - '2.0.x'
+          - 'devel'
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macOS-latest
+    name: '${{ matrix.nim }} (${{ matrix.os }})'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           path: unchained
 
-      - name: Setup Nim
-        uses: alaviss/setup-nim@0.1.1
+
+      - name: Setup nim
+        uses: jiro4989/setup-nim-action@v1
         with:
-          path: nim
-          version: ${{ matrix.branch }}
+          nim-version: ${{ matrix.nim }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup MSYS2 (Windows)
         if: ${{matrix.target == 'windows'}}

--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,7 @@
+* v0.4.2
+- minor fix to ~to~ such that we use exactly the type as given by the
+  user, instead of ~yCT.toNimType()~. This is to guarantee the
+  property ~x.to(T) is T~ always holds.
 * v0.4.1
 - fix issue #48 where the unit parsing logic accepted invalid SI
   prefixes and thus code like ~foo.toMeter~ was valid (and looked like

--- a/unchained.nimble
+++ b/unchained.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.4.1"
+version       = "0.4.2"
 author        = "Vindaar"
 description   = "Fully type safe, compile time only units library"
 license       = "MIT"


### PR DESCRIPTION
This is to guarantee the property `x.to(T) is T` always holds. This is needed in Measuremancer's `FloatLike` concept.