### PR TITLE
Fix `sqrt` to simplify to base units, add `simplify` to turn unit into SI base units

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,3 +1,8 @@
+* v0.4.8
+- fixes ~sqrt~ such that it works correctly when something is a
+  perfect square in *SI base units* and not just if the compound unit
+  itself is a perfect square
+- add ~simplify~ which converts the input into the compound of base SI units  
 * v0.4.7
 - support ~range[T]~ types. Previously caused error when determining
   associated "unit"

--- a/src/unchained/ct_unit_types.nim
+++ b/src/unchained/ct_unit_types.nim
@@ -265,7 +265,7 @@ proc contains*(tab: UnitTable, u: string): bool =
 proc isUserDefined*(tab: UnitTable, u: string): bool =
   result = u in tab.userDefinedUnits
 
-proc insert*(tab: var UnitTable, u: DefinedUnit, hasConversion: bool,
+proc insert*(tab: UnitTable, u: DefinedUnit, hasConversion: bool,
              compoundName = "") =
   ## Inserts the given `u` into the `UnitTable`. The correct sub field will be filled
   ## based on `isLong`
@@ -292,7 +292,7 @@ proc insert*(tab: var UnitTable, u: DefinedUnit, hasConversion: bool,
   tab.short[u.short] = idx
   tab.units.add u
 
-proc insert*(tab: var UnitTable, unit: string, asUnit: UnitProduct) =
+proc insert*(tab: UnitTable, unit: string, asUnit: UnitProduct) =
   ## Insert the given user defined unit `unit`
   if unit != "UnitLess" and unit notin tab and unit notin tab.userDefinedUnits:
     tab.userDefinedUnits[unit] = asUnit

--- a/src/unchained/define_units.nim
+++ b/src/unchained/define_units.nim
@@ -90,7 +90,7 @@ proc toNimType*(u: UnitInstance, short = false,
       else:
         result.add DigitsAscii[digit]
 
-proc toNimTypeStr*(tab: var UnitTable, x: UnitProduct, short = false,
+proc toNimTypeStr*(tab: UnitTable, x: UnitProduct, short = false,
                    internal: static bool = true): string =
   ## converts `x` to the correct string representation
   # return early if no units in x or if we know the unit's string repr
@@ -445,7 +445,7 @@ proc assertOption(n: NimNode): bool =
     n[0].kind == nnkIdent and
     n[1].kind == nnkStmtList
 
-proc parseUnit(tab: var UnitTable, id: int, n: NimNode): DefinedUnit =
+proc parseUnit(tab: UnitTable, id: int, n: NimNode): DefinedUnit =
   ## Parses:
   ##
   ##  Call
@@ -494,7 +494,7 @@ proc parseUnit(tab: var UnitTable, id: int, n: NimNode): DefinedUnit =
   else:
     tab.insert(result, hasConversion)
 
-proc parseUnits(tab: var UnitTable, id: var int, n: NimNode): DefinedUnits =
+proc parseUnits(tab: UnitTable, id: var int, n: NimNode): DefinedUnits =
   ## Handles parsing the given base units or derived units
   ##
   ##    StmtList
@@ -511,7 +511,7 @@ proc parseUnits(tab: var UnitTable, id: var int, n: NimNode): DefinedUnits =
     result.add tab.parseUnit(id, unit)
     inc id
 
-proc addNaturalUnitConversions(tab: var UnitTable, n: NimNode) =
+proc addNaturalUnitConversions(tab: UnitTable, n: NimNode) =
   ## Parses the following tree and adjusts the `toNaturalUnit` conversion
   ## field for the referenced units.
   ## Call
@@ -544,7 +544,7 @@ proc addNaturalUnitConversions(tab: var UnitTable, n: NimNode) =
     definedUnit.toNaturalUnit = conv
     tab.units[idx] = definedUnit
 
-proc parseCall(tab: var UnitTable, id: var int, c: NimNode): DefinedUnits =
+proc parseCall(tab: UnitTable, id: var int, c: NimNode): DefinedUnits =
   ## Handles dispatching based on base units / derived ident
   ##
   ##  Call

--- a/src/unchained/parse_units.nim
+++ b/src/unchained/parse_units.nim
@@ -5,6 +5,12 @@ import core_types, ct_unit_types, macro_utils
 
 from std / tables import getOrDefault, `[]`
 
+template errorMsg(msg: string): untyped =
+  when nimvm:
+    error(msg)
+  else:
+    raise newException(ValueError, msg)
+
 proc parseSiPrefixShort(c: Rune): SiPrefix =
   ## For the case of short SI prefixes (i.e. single character) return it
   result = SiShortPrefixStrTable.getOrDefault($c, siIdentity) # initialize with identity, in case none match
@@ -51,7 +57,7 @@ proc parsePrefixAndUnit(tab: UnitTable, x: string, start, stop: int):
       result.prefix = parseSiPrefixShort(x.runeAt(start))
       result.unit = tab.getShort($x[stop-1])
       if result.prefix == siIdentity:
-        error("The prefix `" & $x.runeAt(start) & "` of the unit `" & x & "` is not a valid prefix!")
+        errorMsg("The prefix `" & $x.runeAt(start) & "` of the unit `" & x & "` is not a valid prefix!")
   else:
     # try any unit
     var unitOpt = tab.tryLookupUnit(x[start ..< stop])
@@ -64,7 +70,7 @@ proc parsePrefixAndUnit(tab: UnitTable, x: string, start, stop: int):
         result.unit = unitOpt.get
         result.prefix = parseSiPrefixShort(x.runeAt(start)) # in this case prefix must be short
         if result.prefix == siIdentity:
-          error("The prefix `" & $x.runeAt(start) & "` of the unit `" & x & "` is not a valid prefix!")
+          errorMsg("The prefix `" & $x.runeAt(start) & "` of the unit `" & x & "` is not a valid prefix!")
       else:
         # must be long + long, e.g. `KiloGram`
         # must have prefix, thus parse until upper, that defines prefix & unit
@@ -79,7 +85,7 @@ proc parsePrefixAndUnit(tab: UnitTable, x: string, start, stop: int):
           result.prefix = parseSiPrefixLong(x[start] & prefixStr)
           result.unit = tab.lookupUnit(x[start + prefixNum + 1 ..< stop])
           if result.prefix == siIdentity:
-            error("The prefix `" & $x[start] & prefixStr & "` of the unit `" & x & "` is not a valid prefix!")
+            errorMsg("The prefix `" & $x[start] & prefixStr & "` of the unit `" & x & "` is not a valid prefix!")
 
 template addUnit(): untyped {.dirty.} =
   ## Dirty template used in both parsing procedures (unicode & ascii)
@@ -232,12 +238,12 @@ proc tryLookupUnitType*(tab: UnitTable, n: NimNode): Option[UnitProduct] =
           doAssert nTyp[1].kind in [nnkSym, nnkIdent], "Typedesc argument is not a symbol: " & $nTyp.treerepr
           nStr = nTyp[1].strVal
         else:
-          error("Unexpected type: " & $nTyp.treerepr & " for input: " & $n.treerepr)
+          errorMsg("Unexpected type: " & $nTyp.treerepr & " for input: " & $n.treerepr)
       else:
-        error("Unexpected type: " & $nTyp.treerepr & " for input: " & $n.treerepr)
+        errorMsg("Unexpected type: " & $nTyp.treerepr & " for input: " & $n.treerepr)
     of nnkDistinctTy: nStr = nTyp[1].strVal
     of nnkSym: nStr = nTyp.strVal
-    else: error("Invalid node for type : " & nTyp.repr)
+    else: errorMsg("Invalid node for type : " & nTyp.repr)
 
     result = fromTab(tab, nStr)
   of nnkTypeOfExpr:

--- a/src/unchained/parse_units.nim
+++ b/src/unchained/parse_units.nim
@@ -253,7 +253,7 @@ proc tryLookupUnitType*(tab: UnitTable, n: NimNode): Option[UnitProduct] =
       let nTyp = n.getTypeInst
       result = tab.tryLookupUnitType(nTyp)
 
-proc parseDefinedUnit*(tab: var UnitTable, x: NimNode): UnitProduct =
+proc parseDefinedUnit*(tab: UnitTable, x: NimNode): UnitProduct =
   result = initUnitProduct()
   # first check if part of previously user defined units
   let resOpt = tab.tryLookupUnitType(x)

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -395,7 +395,12 @@ macro sqrt*[T: SomeUnit](t: T): untyped =
   ##
   ## Fails if the given unit is not a perfect square (i.e. each compound of the full
   ## unit's power is a multiple of 2).
-  let typ = t.parseDefinedUnit()
+  ##
+  ## NOTE: If the given input is a perfect square of a set of SI base units, but the
+  ## input itself is given as a combination of derived units, we'll convert to the
+  ## SI base units and take the sqrt of that.
+  ## E.g. W·Ω⁻¹ = A² and thus `sqrt(1.W·Ω⁻¹)` will return `1.A`.
+  let typ = t.parseDefinedUnit().flatten().simplify()
 
   var mType = typ
   for u in mitems(mType.units):

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -594,3 +594,13 @@ macro toNaturalUnit*[T: SomeUnit](t: T): untyped =
   result = quote do:
     defUnit(`resType`)
     `resType`(`t`.FloatType * `scale`)
+
+macro simplify*[T: SomeUnit](t: T): untyped =
+  ## Returns the simplest form in SI base units of the given input.
+  var typ = t.parseDefinedUnit()
+  let resType = typ.flatten().simplify()
+  let scale = typ.toBaseTypeScale() / resType.toBaseTypeScale()
+  let resTypeNim = resType.toNimType()
+  result = quote do:
+    defUnit(`resTypeNim`)
+    `resTypeNim`(`t`.FloatType * `scale`)

--- a/src/unchained/units.nim
+++ b/src/unchained/units.nim
@@ -534,6 +534,9 @@ macro toBaseUnits*[T: SomeUnit](x: T): untyped =
   let resType = xCT.flatten().toBaseType(true).simplify(mergePrefixes = true).toNimType
   result = quote do:
     `x`.toDef(`resType`)
+template simplify*[T: SomeUnit](x: T): untyped =
+  ## Alias for `toBaseUnits`. Converts the given input to base SI units
+  toBaseUnits(x)
 
 ## Natural unit stuff
 proc toNaturalUnitImpl(t: UnitProduct): UnitProduct
@@ -594,13 +597,3 @@ macro toNaturalUnit*[T: SomeUnit](t: T): untyped =
   result = quote do:
     defUnit(`resType`)
     `resType`(`t`.FloatType * `scale`)
-
-macro simplify*[T: SomeUnit](t: T): untyped =
-  ## Returns the simplest form in SI base units of the given input.
-  var typ = t.parseDefinedUnit()
-  let resType = typ.flatten().simplify()
-  let scale = typ.toBaseTypeScale() / resType.toBaseTypeScale()
-  let resTypeNim = resType.toNimType()
-  result = quote do:
-    defUnit(`resTypeNim`)
-    `resTypeNim`(`t`.FloatType * `scale`)

--- a/tests/tunchained.nim
+++ b/tests/tunchained.nim
@@ -481,6 +481,7 @@ suite "Unchained - Conversion between units":
     let x = 1.kJ
     check typeof(x.simplify()) is kg•m²•s⁻²
     check x.simplify() == 1000.kg•m²•s⁻²
+    check x.toBaseUnits() == 1000.kg•m²•s⁻²
 
 suite "Unchained - CT errors":
   test "Error on regular digit as exponent":

--- a/tests/tunchained.nim
+++ b/tests/tunchained.nim
@@ -1069,6 +1069,13 @@ suite "Unchained - Bug issues":
       check typeof(x * y) is kg
       check typeof(y / x) is kg
 
+  test "sqrt works on products of compound units, which don't appear to be a perfect square (but are)":
+    let x = 1.W
+    let y = 1.Ω⁻¹
+    check typeof(x * y) is A²
+    check typeof(sqrt(x * y)) is A
+    check sqrt(x * y) == 1.A
+
 suite "Utils":
   test "Power w/ static integer exponents for floats":
     let x = 5

--- a/tests/tunchained.nim
+++ b/tests/tunchained.nim
@@ -477,6 +477,11 @@ suite "Unchained - Conversion between units":
     # "default", as it is defined first!
     check $typeof(foo0()) == "Joule"
 
+  test "Simplify to SI base units converts correctly":
+    let x = 1.kJ
+    check typeof(x.simplify()) is kg•m²•s⁻²
+    check x.simplify() == 1000.kg•m²•s⁻²
+
 suite "Unchained - CT errors":
   test "Error on regular digit as exponent":
     doAssert fails(10.kg•m⁻2) # invalid `2` instead of `²`


### PR DESCRIPTION
Now something like `W·Ω⁻¹` can be correctly taken the `sqrt` of (to yield units of Ampere).

Also added a `simplify` function, which turns the given compound into base SI units. ~~I think we didn't have a public API  or that~~, yes we did `toBaseUnits`. Leaving `simplify` as an alias).