### PR TITLE
Fix the (very minor) error in the `m_e_c2` constant

### DIFF
--- a/src/unchained/constants.nim
+++ b/src/unchained/constants.nim
@@ -13,7 +13,7 @@ const
   e* = 1.602176634e-19.C
   ## Mass of an electron.
   m_e* = 9.1093837015e-31.kg
-  m_e_c2* = 0.510998928.MeV
+  m_e_c2* = 0.510998950.MeV
   ## Mass of a muon.
   m_μ* = 1.883531627e-28.kg # 105.6583755e3 # MeV / c²
   m_μ_eV* = 105.6583755e6.eV # / c²


### PR DESCRIPTION
The `m_e_c2` value is 22eV below the one in CODATA Recommended Values of the Fundamental Physical Constants (https://doi.org/10.1063/5.0064853), which seems to be the source of other constants. Not sure where `0.510998928` came from. Very minor thing but may cause discrepancies with other tools in high precision calculations.

This one-liner PR adjusts this.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/fa218b45-7f31-4206-89e4-2c5327af3751" />
